### PR TITLE
Make the timeout tests be bullet proof by shimming out the nio selectors...

### DIFF
--- a/nifty-examples/src/test/java/com/facebook/nifty/server/DeafSelectorProvider.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/DeafSelectorProvider.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.server;
+
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.ProtocolFamily;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.AbstractSelectableChannel;
+import java.nio.channels.spi.AbstractSelector;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.Collections;
+import java.util.Set;
+
+public class DeafSelectorProvider extends SelectorProvider
+{
+    @Override
+    public DatagramChannel openDatagramChannel() throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public DatagramChannel openDatagramChannel(ProtocolFamily family) throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public Pipe openPipe() throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public AbstractSelector openSelector() throws IOException
+    {
+        return new AbstractSelector(this) {
+
+            private final Set<SelectionKey> keys = Sets.newHashSet();
+
+            @Override
+            protected void implCloseSelector() throws IOException
+            {
+            }
+
+            @Override
+            protected SelectionKey register(AbstractSelectableChannel ch, int ops, Object att)
+            {
+                final AbstractSelector selector = this;
+
+                final SelectionKey key = new SelectionKey() {
+
+                    @Override
+                    public Selector selector()
+                    {
+                        return selector;
+                    }
+
+                    @Override
+                    public int readyOps()
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean isValid()
+                    {
+                        return true;
+                    }
+
+                    @Override
+                    public SelectionKey interestOps(int ops)
+                    {
+                        return this;
+                    }
+
+                    @Override
+                    public int interestOps()
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public SelectableChannel channel()
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public void cancel()
+                    {
+                    }
+                };
+                key.interestOps(ops);
+                key.attach(att);
+
+                keys.add(key);
+                return key;
+            }
+
+
+            @Override
+            public Set<SelectionKey> keys()
+            {
+                return keys;
+            }
+
+            @Override
+            public Set<SelectionKey> selectedKeys()
+            {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public int selectNow() throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public int select(long timeout) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public int select() throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public Selector wakeup()
+            {
+                return null;
+            }
+
+        };
+    }
+
+    @Override
+    public ServerSocketChannel openServerSocketChannel() throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public SocketChannel openSocketChannel() throws IOException
+    {
+        return new SocketChannel(this) {
+
+            @Override
+            public SocketAddress getLocalAddress() throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public <T> T getOption(SocketOption<T> name) throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public Set<SocketOption<?>> supportedOptions()
+            {
+                return null;
+            }
+
+            @Override
+            public SocketChannel bind(SocketAddress local) throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public <T> SocketChannel setOption(SocketOption<T> name, T value) throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public SocketChannel shutdownInput() throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public SocketChannel shutdownOutput() throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public Socket socket()
+            {
+                return new Socket();
+            }
+
+            @Override
+            public boolean isConnected()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isConnectionPending()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean connect(SocketAddress remote) throws IOException
+            {
+                return false;
+            }
+
+            @Override
+            public boolean finishConnect() throws IOException
+            {
+                return false;
+            }
+
+            @Override
+            public SocketAddress getRemoteAddress() throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public int read(ByteBuffer dst) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public long read(ByteBuffer[] dsts, int offset, int length) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public int write(ByteBuffer src) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public long write(ByteBuffer[] srcs, int offset, int length) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            protected void implCloseSelectableChannel() throws IOException
+            {
+            }
+
+            @Override
+            protected void implConfigureBlocking(boolean block) throws IOException
+            {
+            }
+        };
+    }
+}
+

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/DeafSelectorProvider.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/DeafSelectorProvider.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.server;
+
+import com.google.common.collect.Sets;
+
+import java.io.IOException;
+import java.net.ProtocolFamily;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.AbstractSelectableChannel;
+import java.nio.channels.spi.AbstractSelector;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * An implementation of {@link SelectorProvider}, which is nifty's way to get sockets
+ * for the clients that totally ignores all bind and connect requests. Therefore any
+ * attempt to connect to a server will run into the connection timeout.
+ *
+ * This is useful to test the timeout logic in the nifty client.
+ */
+public class DeafSelectorProvider extends SelectorProvider
+{
+    @Override
+    public DatagramChannel openDatagramChannel() throws IOException
+    {
+        throw new UnsupportedOperationException("openDatagramChannel");
+    }
+
+    @Override
+    public DatagramChannel openDatagramChannel(ProtocolFamily family) throws IOException
+    {
+        throw new UnsupportedOperationException("openDatagramChannel");
+    }
+
+    @Override
+    public Pipe openPipe() throws IOException
+    {
+        throw new UnsupportedOperationException("openPipe");
+    }
+
+    @Override
+    public AbstractSelector openSelector() throws IOException
+    {
+        return new AbstractSelector(this) {
+
+            private final Set<SelectionKey> keys = Sets.newHashSet();
+
+            @Override
+            protected void implCloseSelector() throws IOException
+            {
+            }
+
+            @Override
+            protected SelectionKey register(final AbstractSelectableChannel ch, final int ops, final Object att)
+            {
+                final AbstractSelector selector = this;
+
+                final SelectionKey key = new SelectionKey() {
+
+                    @Override
+                    public Selector selector()
+                    {
+                        return selector;
+                    }
+
+                    @Override
+                    public int readyOps()
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean isValid()
+                    {
+                        return true;
+                    }
+
+                    @Override
+                    public SelectionKey interestOps(int ops)
+                    {
+                        return this;
+                    }
+
+                    @Override
+                    public int interestOps()
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public SelectableChannel channel()
+                    {
+                        return ch;
+                    }
+
+                    @Override
+                    public void cancel()
+                    {
+                    }
+                };
+                key.interestOps(ops);
+                key.attach(att);
+
+                keys.add(key);
+                return key;
+            }
+
+
+            @Override
+            public Set<SelectionKey> keys()
+            {
+                return keys;
+            }
+
+            @Override
+            public Set<SelectionKey> selectedKeys()
+            {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public int selectNow() throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public int select(long timeout) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public int select() throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public Selector wakeup()
+            {
+                return this;
+            }
+
+        };
+    }
+
+    @Override
+    public ServerSocketChannel openServerSocketChannel() throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public SocketChannel openSocketChannel() throws IOException
+    {
+        return new SocketChannel(this) {
+
+            final Socket socket = new Socket();
+
+            @Override
+            public SocketAddress getLocalAddress() throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public <T> T getOption(SocketOption<T> name) throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public Set<SocketOption<?>> supportedOptions()
+            {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public SocketChannel bind(SocketAddress local) throws IOException
+            {
+                return this;
+            }
+
+            @Override
+            public <T> SocketChannel setOption(SocketOption<T> name, T value) throws IOException
+            {
+                return this;
+            }
+
+            @Override
+            public SocketChannel shutdownInput() throws IOException
+            {
+                return this;
+            }
+
+            @Override
+            public SocketChannel shutdownOutput() throws IOException
+            {
+                return this;
+            }
+
+            @Override
+            public Socket socket()
+            {
+                return socket;
+            }
+
+            @Override
+            public boolean isConnected()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isConnectionPending()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean connect(SocketAddress remote) throws IOException
+            {
+                return false;
+            }
+
+            @Override
+            public boolean finishConnect() throws IOException
+            {
+                return false;
+            }
+
+            @Override
+            public SocketAddress getRemoteAddress() throws IOException
+            {
+                return null;
+            }
+
+            @Override
+            public int read(ByteBuffer dst) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public long read(ByteBuffer[] dsts, int offset, int length) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public int write(ByteBuffer src) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            public long write(ByteBuffer[] srcs, int offset, int length) throws IOException
+            {
+                return 0;
+            }
+
+            @Override
+            protected void implCloseSelectableChannel() throws IOException
+            {
+            }
+
+            @Override
+            protected void implConfigureBlocking(boolean block) throws IOException
+            {
+            }
+        };
+    }
+}
+

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.server;
+
+import com.facebook.nifty.client.FramedClientChannel;
+import com.facebook.nifty.client.NiftyClient;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.fail;
+
+public class TestNiftyClientTimeout
+{
+    private static final Duration TEST_CONNECT_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final Duration TEST_READ_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final Duration TEST_WRITE_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+
+    @BeforeTest(alwaysRun = true)
+    public void setup() throws IOException
+    {
+        System.setProperty("java.nio.channels.spi.SelectorProvider", DeafSelectorProvider.class.getName());
+    }
+
+    @AfterTest(alwaysRun = true)
+    public void tearDown()
+    {
+        System.clearProperty("java.nio.channels.spi.SelectorProvider");
+    }
+
+    @Test(timeOut = 2000)
+    public void testSyncConnectTimeout() throws ConnectException, IOException
+    {
+        ServerSocket serverSocket = new ServerSocket(0);
+        int port = serverSocket.getLocalPort();
+
+        final NiftyClient client = new NiftyClient();
+        try {
+                client.connectSync(new InetSocketAddress(port),
+                                   TEST_CONNECT_TIMEOUT,
+                                   TEST_READ_TIMEOUT,
+                                   TEST_WRITE_TIMEOUT);
+        }
+        catch (Throwable throwable) {
+            if (isTimeoutException(throwable)) {
+                return;
+            }
+            Throwables.propagate(throwable);
+        }
+        finally {
+            client.close();
+            serverSocket.close();
+        }
+
+        // Should never get here
+        fail("Connection succeeded but failure was expected");
+    }
+
+    @Test(timeOut = 2000)
+    public void testAsyncConnectTimeout() throws IOException
+    {
+        ServerSocket serverSocket = new ServerSocket(0);
+        int port = serverSocket.getLocalPort();
+
+        final NiftyClient client = new NiftyClient();
+        try {
+            ListenableFuture<FramedClientChannel> future =
+                            client.connectAsync(new FramedClientChannel.Factory(),
+                                                new InetSocketAddress(port),
+                                                TEST_CONNECT_TIMEOUT,
+                                                TEST_READ_TIMEOUT,
+                                                TEST_WRITE_TIMEOUT);
+            // Wait while NiftyClient attempts to connect the channel
+            future.get();
+        }
+        catch (Throwable throwable) {
+            if (isTimeoutException(throwable)) {
+                return;
+            }
+            Throwables.propagate(throwable);
+        }
+        finally {
+            client.close();
+            serverSocket.close();
+        }
+
+        // Should never get here
+        fail("Connection succeeded but failure was expected");
+    }
+
+    private boolean isTimeoutException(Throwable throwable) {
+        Throwable rootCause = Throwables.getRootCause(throwable);
+        // Look for a java.net.ConnectException, with the message "connection timed out"
+        return (rootCause instanceof ConnectException &&
+                rootCause.getMessage().compareTo("connection timed out") == 0);
+    }
+}

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.server;
+
+import com.facebook.nifty.client.FramedClientChannel;
+import com.facebook.nifty.client.NiftyClient;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.fail;
+
+public class TestNiftyClientTimeout
+{
+    private static final Duration TEST_CONNECT_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final Duration TEST_READ_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final Duration TEST_WRITE_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+
+    @BeforeTest(alwaysRun = true)
+    public void setup() throws IOException
+    {
+        System.setProperty("java.nio.channels.spi.SelectorProvider", DeafSelectorProvider.class.getName());
+    }
+
+    @AfterTest(alwaysRun = true)
+    public void tearDown()
+    {
+        System.clearProperty("java.nio.channels.spi.SelectorProvider");
+    }
+
+    @Test(timeOut = 2000)
+    public void testSyncConnectTimeout() throws ConnectException, IOException
+    {
+        ServerSocket serverSocket = new ServerSocket(0, 1);
+        int port = serverSocket.getLocalPort();
+
+        final NiftyClient client = new NiftyClient();
+        try {
+                client.connectSync(new InetSocketAddress(port),
+                                   TEST_CONNECT_TIMEOUT,
+                                   TEST_READ_TIMEOUT,
+                                   TEST_WRITE_TIMEOUT);
+        }
+        catch (Throwable throwable) {
+            if (isTimeoutException(throwable)) {
+                return;
+            }
+            Throwables.propagate(throwable);
+        }
+        finally {
+            client.close();
+            serverSocket.close();
+        }
+
+        // Should never get here
+        fail("Connection succeeded but failure was expected");
+    }
+
+    @Test(timeOut = 2000)
+    public void testAsyncConnectTimeout() throws IOException
+    {
+        ServerSocket serverSocket = new ServerSocket(0, 1);
+        int port = serverSocket.getLocalPort();
+
+        final NiftyClient client = new NiftyClient();
+        try {
+            ListenableFuture<FramedClientChannel> future =
+                            client.connectAsync(new FramedClientChannel.Factory(),
+                                                new InetSocketAddress(port),
+                                                TEST_CONNECT_TIMEOUT,
+                                                TEST_READ_TIMEOUT,
+                                                TEST_WRITE_TIMEOUT);
+            // Wait while NiftyClient attempts to connect the channel
+            future.get();
+        }
+        catch (Throwable throwable) {
+            if (isTimeoutException(throwable)) {
+                return;
+            }
+            Throwables.propagate(throwable);
+        }
+        finally {
+            client.close();
+            serverSocket.close();
+        }
+
+        // Should never get here
+        fail("Connection succeeded but failure was expected");
+    }
+
+    private boolean isTimeoutException(Throwable throwable) {
+        Throwable rootCause = Throwables.getRootCause(throwable);
+        // Look for a java.net.ConnectException, with the message "connection timed out"
+        return (rootCause instanceof ConnectException &&
+                rootCause.getMessage().compareTo("connection timed out") == 0);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.8.1</version>
+                    <configuration>
+                      <forkMode>always</forkMode>
+                    </configuration>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
                                     <version>3.0.0</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>1.6</version>
+                                    <version>1.7</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -157,6 +157,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.8.1</version>
+                    <configuration>
+                      <forkMode>always</forkMode>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -181,8 +184,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
The current code tries to shim the server sockets by simulating a "full" socket. This does not work e.g. on Linux JDK 1.7. 

This change uses a separate selector provider to simulate a non-connecting client. As the test  changes the SelectotrProvider implementation, it needs to be in a separate class and the surefire plugin must fork for each test. 
