### PR TITLE
make the license formatter correctly obey the inception and current year

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/AbstractClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/AbstractClientChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/FramedClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/FramedClientChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/HttpClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/HttpClientChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClient.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientChannelPipelineFactory.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientChannelPipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TChannelBufferInputTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TChannelBufferInputTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TChannelBufferOutputTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TChannelBufferOutputTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyAsyncClientTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyAsyncClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientAdapter.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientListener.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyReadOnlyTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyReadOnlyTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/UnframedClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/UnframedClientChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/socks/SettableChannelFuture.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/socks/SettableChannelFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/socks/Socks4ClientBootstrap.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/socks/Socks4ClientBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/socks/Socks4HandshakeHandler.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/socks/Socks4HandshakeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/socks/SocksProtocols.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/socks/SocksProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-client/src/main/java/com/facebook/nifty/core/ThriftUnframedDecoder.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/core/ThriftUnframedDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ChannelStatistics.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ChannelStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/IdleDisconnectHandler.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/IdleDisconnectHandler.java
@@ -1,17 +1,17 @@
-/**
- * Copyright 2013 Facebook, Inc.
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License. You may obtain
- * a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.facebook.nifty.core;
 

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyConfigBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyConfigBuilderBase.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyConfigBuilderBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyThriftDecoder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyThriftDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyBootstrap.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftFrameDecoder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftFrameDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftTransportType.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftTransportType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/main/java/com/facebook/nifty/guice/NiftyModule.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/guice/NiftyModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/test/java/com/facebook/nifty/core/TestCodec.java
+++ b/nifty-core/src/test/java/com/facebook/nifty/core/TestCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/test/java/com/facebook/nifty/core/TestNettyConfigBuilder.java
+++ b/nifty-core/src/test/java/com/facebook/nifty/core/TestNettyConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-core/src/test/java/com/facebook/nifty/core/TestServerDefBuilder.java
+++ b/nifty-core/src/test/java/com/facebook/nifty/core/TestServerDefBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/main/java/com/facebook/nifty/server/Plain.java
+++ b/nifty-examples/src/main/java/com/facebook/nifty/server/Plain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/main/java/com/facebook/nifty/test/LogEntry.java
+++ b/nifty-examples/src/main/java/com/facebook/nifty/test/LogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/main/java/com/facebook/nifty/test/ResultCode.java
+++ b/nifty-examples/src/main/java/com/facebook/nifty/test/ResultCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/main/java/com/facebook/nifty/test/scribe.java
+++ b/nifty-examples/src/main/java/com/facebook/nifty/test/scribe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/DeafSelectorProvider.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/DeafSelectorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/DelegateSelectorProvider.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/DelegateSelectorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainClient.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-examples/src/test/resources/log4j.properties
+++ b/nifty-examples/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012 Facebook, Inc.
+# Copyright (C) 2012-2013 Facebook, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadError.java
+++ b/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadTest.java
+++ b/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadTestHandler.java
+++ b/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadTestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadTesterNettyConfigProvider.java
+++ b/nifty-load-tester/src/main/java/com/facebook/nifty/perf/LoadTesterNettyConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nifty-load-tester/src/main/java/com/facebook/nifty/perf/NiftyLoadTester.java
+++ b/nifty-load-tester/src/main/java/com/facebook/nifty/perf/NiftyLoadTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2012-2013 Facebook, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -177,5 +177,17 @@ limitations under the License.
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila.maven-license-plugin</groupId>
+                <artifactId>maven-license-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <inceptionYear>${project.inceptionYear}</inceptionYear>
+                        <year>2013</year>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/src/license/LICENSE-HEADER.txt
+++ b/src/license/LICENSE-HEADER.txt
@@ -1,4 +1,4 @@
-Copyright (C) ${year} Facebook, Inc.
+Copyright (C) ${inceptionYear}-${year} Facebook, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Small fix in the license header, and reformatting the headers.
