### PR TITLE
Fix shutdown hangs

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyBootstrap.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyBootstrap.java
@@ -17,10 +17,9 @@ package com.facebook.nifty.core;
 
 import com.google.inject.Inject;
 import org.jboss.netty.channel.group.ChannelGroup;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.util.HashedWheelTimer;
 import org.jboss.netty.util.Timer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -28,22 +27,18 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A lifecycle object that manages starting up and shutting down multiple core channels.
  */
 public class NiftyBootstrap
 {
-    private static final Logger log = LoggerFactory.getLogger(NiftyBootstrap.class);
-
     private final ChannelGroup allChannels;
     private ArrayList<NettyServerTransport> transports;
     private ExecutorService bossExecutor;
     private ExecutorService workerExecutor;
     private final Timer timer;
+    private NioServerSocketChannelFactory serverChannelFactory;
 
     /**
      * This takes a Set of ThriftServerDef. Use Guice Multibinder to inject.
@@ -69,10 +64,11 @@ public class NiftyBootstrap
     @PostConstruct
     public void start()
     {
-        bossExecutor = Executors.newCachedThreadPool(new NamedThreadFactory("nifty-boss"));
-        workerExecutor = Executors.newCachedThreadPool(new NamedThreadFactory("nifty-worker"));
+        bossExecutor = Executors.newCachedThreadPool();
+        workerExecutor = Executors.newCachedThreadPool();
+        serverChannelFactory = new NioServerSocketChannelFactory(bossExecutor, workerExecutor);
         for (NettyServerTransport transport : transports) {
-            transport.start(bossExecutor, workerExecutor);
+            transport.start(serverChannelFactory);
         }
     }
 
@@ -87,60 +83,8 @@ public class NiftyBootstrap
                 Thread.currentThread().interrupt();
             }
         }
-        // stop bosses
-        if (bossExecutor != null) {
-            shutdownExecutor(bossExecutor, "bossExecutor");
-            bossExecutor = null;
-        }
 
-        // TODO : allow an option here to control if we need to drain connections and wait instead of killing them all
-
-        try {
-            allChannels.close();
-        }
-        catch (Exception e) {
-            log.warn("ignored exception while shutting down channels", e);
-        }
-
-        // finally the reader writer
-        if (workerExecutor != null) {
-            shutdownExecutor(workerExecutor, "workerExecutor");
-            workerExecutor = null;
-        }
-    }
-
-    // TODO : make wait time configurable ?
-    static void shutdownExecutor(ExecutorService executor, final String name)
-    {
-        executor.shutdown();
-        try {
-            log.info("waiting for {} to shutdown", name);
-            executor.awaitTermination(5, TimeUnit.SECONDS);
-        }
-        catch (InterruptedException e) {
-            //ignored
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    public static class NamedThreadFactory implements ThreadFactory
-    {
-        private final String baseName;
-        private final AtomicInteger threadNum = new AtomicInteger(0);
-
-        public NamedThreadFactory(String baseName)
-        {
-            this.baseName = baseName;
-        }
-
-        @Override
-        public synchronized Thread newThread(Runnable r)
-        {
-            Thread t = Executors.defaultThreadFactory().newThread(r);
-
-            t.setName(baseName + "-" + threadNum.getAndIncrement());
-
-            return t;
-        }
+        ShutdownUtil.shutdownChannelFactory(serverChannelFactory, bossExecutor,
+                                            workerExecutor, allChannels);
     }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ShutdownUtil.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ShutdownUtil.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.nifty.core;
+
+import org.jboss.netty.channel.ChannelFactory;
+import org.jboss.netty.channel.group.ChannelGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ShutdownUtil
+{
+    private static final Logger log = LoggerFactory.getLogger(ShutdownUtil.class);
+
+    public static void shutdownChannelFactory(ChannelFactory channelFactory,
+                                              ExecutorService bossExecutor,
+                                              ExecutorService workerExecutor,
+                                              ChannelGroup allChannels)
+    {
+        // Close all channels
+        if (allChannels != null) {
+            closeChannels(allChannels);
+        }
+
+        // Shutdown the channel factory
+        if (channelFactory != null) {
+            channelFactory.shutdown();
+        }
+
+        // Stop boss threads
+        if (bossExecutor != null) {
+            shutdownExecutor(bossExecutor, "bossExecutor");
+        }
+
+        // Finally stop I/O workers
+        if (workerExecutor != null) {
+            shutdownExecutor(workerExecutor, "workerExecutor");
+        }
+    }
+
+    public static void closeChannels(ChannelGroup allChannels)
+    {
+        if (allChannels.size() > 0)
+        {
+            // TODO : allow an option here to control if we need to drain connections and wait instead of killing them all
+            try {
+                log.info("Closing " + allChannels.size() + " open client connections");
+                if (!allChannels.close().await(5, TimeUnit.SECONDS)) {
+                    log.warn("Failed to close all open client connections");
+                }
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while closing client connections");
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    // TODO : make wait time configurable ?
+    public static void shutdownExecutor(ExecutorService executor, final String name)
+    {
+        executor.shutdown();
+        try {
+            log.info("Waiting for {} to shutdown", name);
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                log.warn("{} did not shutdown properly", name);
+            }
+        }
+        catch (InterruptedException e) {
+            log.warn("Interrupted while waiting for {} to shutdown", name);
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
@@ -82,6 +82,7 @@ public class TestNiftyClient
                     bootstrap.stop();
                 }
                 catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }.start();

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -84,7 +84,7 @@ public class TestNiftyClientTimeout
         fail("Connection succeeded but failure was expected");
     }
 
-    @Test(timeOut = 2000)
+    @Test(timeOut = 5000)
     public void testAsyncConnectTimeout() throws IOException
     {
         ServerSocket serverSocket = new ServerSocket(0);


### PR DESCRIPTION
Cleanup of the NiftyBootstrap/NiftyClient shutdown code. Before this, some tests
failed on Linux, and some tests that were passing on mac were spinning 100% CPU
for a while after successfully finishing the test.
