### PR TITLE
1 second shutdown delay instead of default of 120s by MoreExecutors.

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClient.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClient.java
@@ -69,8 +69,8 @@ public class NiftyClient implements Closeable
     public NiftyClient(int maxFrameSize)
     {
         this(new NettyClientConfigBuilder(),
-                getExitingExecutorService((ThreadPoolExecutor) newCachedThreadPool()),
-                getExitingExecutorService((ThreadPoolExecutor) newCachedThreadPool()),
+                getExitingExecutorService((ThreadPoolExecutor) newCachedThreadPool(), 1, TimeUnit.SECONDS),
+                getExitingExecutorService((ThreadPoolExecutor) newCachedThreadPool(), 1, TimeUnit.SECONDS),
                 maxFrameSize,
                 null);
     }


### PR DESCRIPTION
changing shutdown delay for this NiftyClient c'tor to 1 second explicitly instead of relying on the default of 120 in MoreExecutors. On shutdown, the shutdown hook created by MoreExecutors is waiting for 120s preventing the JVM to exit quickly.
