### PR TITLE
Move maxFrameSize off of NiftyClient and into connectSync/connectAsync

### DIFF
--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -39,6 +39,7 @@ public class TestNiftyClientTimeout
     private static final Duration TEST_CONNECT_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
     private static final Duration TEST_READ_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
     private static final Duration TEST_WRITE_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final int TEST_MAX_FRAME_SIZE = 16777216;
 
     @BeforeTest(alwaysRun = true)
     public void init() {
@@ -67,7 +68,8 @@ public class TestNiftyClientTimeout
                 client.connectSync(new InetSocketAddress(port),
                                    TEST_CONNECT_TIMEOUT,
                                    TEST_READ_TIMEOUT,
-                                   TEST_WRITE_TIMEOUT);
+                                   TEST_WRITE_TIMEOUT,
+                                   TEST_MAX_FRAME_SIZE);
         }
         catch (Throwable throwable) {
             if (isTimeoutException(throwable)) {
@@ -96,7 +98,8 @@ public class TestNiftyClientTimeout
                             client.connectAsync(new FramedClientConnector(new InetSocketAddress(port)),
                                                 TEST_CONNECT_TIMEOUT,
                                                 TEST_READ_TIMEOUT,
-                                                TEST_WRITE_TIMEOUT);
+                                                TEST_WRITE_TIMEOUT,
+                                                TEST_MAX_FRAME_SIZE);
             // Wait while NiftyClient attempts to connect the channel
             future.get();
         }


### PR DESCRIPTION
This makes it easier to integrate into the swift client configuration settings, which are per client type. The expected max size for a frame will be different depending on the type of service.

(Also changing default max frame size to 16 MB instead of 1 MB, as several of our services return more than 1 MB on a regular basis.)
