### PR TITLE
Nifty thread naming updates

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
@@ -16,6 +16,7 @@
 package com.facebook.nifty.client;
 
 import com.facebook.nifty.core.NettyConfigBuilderBase;
+import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.jboss.netty.channel.socket.nio.NioSocketChannelConfig;
 
@@ -32,6 +33,7 @@ public class NettyClientConfigBuilder extends NettyConfigBuilderBase
     private static final int DEFAULT_WORKER_THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 2;
     private int bossThreadCount = DEFAULT_BOSS_THREAD_COUNT;
     private int workerThreadCount = DEFAULT_WORKER_THREAD_COUNT;
+    private String name = "";
 
     private final NioSocketChannelConfig socketChannelConfig = (NioSocketChannelConfig) Proxy.newProxyInstance(
             getClass().getClassLoader(),
@@ -70,4 +72,17 @@ public class NettyClientConfigBuilder extends NettyConfigBuilderBase
     {
         return workerThreadCount;
     }
+
+    public NettyClientConfigBuilder setNiftyName(String name)
+    {
+        Preconditions.checkNotNull(name, "name is null");
+        this.name = name;
+        return this;
+    }
+
+    public String getNiftyName()
+    {
+        return name;
+    }
+
 }


### PR DESCRIPTION
- allow setting a name prefix for the threads by calling setName() on the NettyClientConfigBuilder
- make netty actually name the threads in the boss and worker pool
  correctly by passing a ThreadNameDeterminer in.

Setting the name of the timer thread will only work after
- https://github.com/netty/netty/pull/1176 was applied
- the next version of netty gets released with this pull request applied
- the line
  `this.hashedWheelTimer = new HashedWheelTimer(renamingDaemonThreadFactory(prefix + "-timer-%s"));`
  is replaced by
  `this.hashedWheelTimer = new HashedWheelTimer(renamingDaemonThreadFactory(prefix + "-timer-%s"), ThreadNameDeterminer.CURRENT);`
