### PR TITLE
Nifty fbcode refactor

### DIFF
--- a/nifty-core/pom.xml
+++ b/nifty-core/pom.xml
@@ -40,6 +40,11 @@ limitations under the License.
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameCodec.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameCodec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.jboss.netty.channel.ChannelEvent;
+import org.jboss.netty.channel.ChannelHandlerContext;
+
+public class DefaultThriftFrameCodec implements ThriftFrameCodec
+{
+    private final ThriftFrameDecoder decoder;
+    private final ThriftFrameEncoder encoder;
+
+    public DefaultThriftFrameCodec(int maxFrameSize, TProtocolFactory inputProtocolFactory)
+    {
+        this.decoder = new DefaultThriftFrameDecoder(maxFrameSize, inputProtocolFactory);
+        this.encoder = new DefaultThriftFrameEncoder(maxFrameSize);
+    }
+
+    @Override
+    public void handleDownstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception
+    {
+        encoder.handleDownstream(ctx, e);
+    }
+
+    @Override
+    public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception
+    {
+        decoder.handleUpstream(ctx, e);
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameCodecFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameCodecFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.jboss.netty.channel.ChannelHandler;
+
+public class DefaultThriftFrameCodecFactory implements ThriftFrameCodecFactory
+{
+    @Override
+    public ChannelHandler create(int maxFrameSize, TProtocolFactory defaultProtocolFactory)
+    {
+        return new DefaultThriftFrameCodec(maxFrameSize, defaultProtocolFactory);
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameDecoder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameDecoder.java
@@ -13,34 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.nifty.core;
+package com.facebook.nifty.codec;
 
+import com.facebook.nifty.core.TNiftyTransport;
+import com.facebook.nifty.core.ThriftMessage;
+import com.facebook.nifty.core.ThriftTransportType;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.protocol.TProtocolUtil;
 import org.apache.thrift.protocol.TType;
-import org.apache.thrift.transport.TTransport;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.Channels;
-import org.jboss.netty.handler.codec.frame.FrameDecoder;
 import org.jboss.netty.handler.codec.frame.TooLongFrameException;
 
-public class ThriftFrameDecoder extends FrameDecoder {
+public class DefaultThriftFrameDecoder extends ThriftFrameDecoder
+{
     public static final int MESSAGE_FRAME_SIZE = 4;
     private final int maxFrameSize;
     private final TProtocolFactory inputProtocolFactory;
 
-    public ThriftFrameDecoder(int maxFrameSize, TProtocolFactory inputProtocolFactory) {
+    public DefaultThriftFrameDecoder(int maxFrameSize, TProtocolFactory inputProtocolFactory)
+    {
         this.maxFrameSize = maxFrameSize;
         this.inputProtocolFactory = inputProtocolFactory;
     }
 
     @Override
-    protected Object decode(ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer)
-            throws Exception {
+    protected ThriftMessage decode(ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer)
+            throws Exception
+    {
         if (!buffer.readable()) {
             return null;
         }
@@ -49,27 +53,39 @@ public class ThriftFrameDecoder extends FrameDecoder {
         if (firstByte >= 0x80) {
             // A non-zero MSB for the first byte of the message implies the message starts with a
             // protocol id (and thus it is unframed).
-            return tryDecodeUnframedMessage(ctx, channel, buffer);
+            return new ThriftMessage(tryDecodeUnframedMessage(ctx, channel, buffer, inputProtocolFactory),
+                                     ThriftTransportType.UNFRAMED);
         } else if (buffer.readableBytes() < MESSAGE_FRAME_SIZE) {
             // Expecting a framed message, but not enough bytes available to read the frame size
             return null;
         } else {
             // Messages with a zero MSB in the first byte are framed messages
-            return tryDecodeFramedMessage(ctx, channel, buffer);
+            return new ThriftMessage(tryDecodeFramedMessage(ctx, channel, buffer, true),
+                                     ThriftTransportType.FRAMED);
         }
-
     }
 
-    private TTransport tryDecodeFramedMessage(ChannelHandlerContext ctx, Channel channel,
-                                              ChannelBuffer buffer) {
+    protected ChannelBuffer tryDecodeFramedMessage(ChannelHandlerContext ctx,
+                                                   Channel channel,
+                                                   ChannelBuffer buffer,
+                                                   boolean stripFraming)
+    {
         // Framed messages are prefixed by the size of the frame (which doesn't include the
         // framing itself).
 
         int messageStartReaderIndex = buffer.readerIndex();
-        // Read the i32 frame contents size
-        int messageContentsLength = buffer.getInt(messageStartReaderIndex);
+        int messageContentsOffset;
+
+        if (stripFraming) {
+            messageContentsOffset = messageStartReaderIndex + MESSAGE_FRAME_SIZE;
+        }
+        else {
+            messageContentsOffset = messageStartReaderIndex;
+        }
+
         // The full message is larger by the size of the frame size prefix
-        int messageLength = messageContentsLength + MESSAGE_FRAME_SIZE;
+        int messageLength = buffer.getInt(messageStartReaderIndex) + MESSAGE_FRAME_SIZE;
+        int messageContentsLength = messageStartReaderIndex + messageLength - messageContentsOffset;
 
         if (messageContentsLength > maxFrameSize) {
             Channels.fireExceptionCaught(
@@ -79,28 +95,29 @@ public class ThriftFrameDecoder extends FrameDecoder {
             );
         }
 
-        int messageContentsOffset = messageStartReaderIndex + MESSAGE_FRAME_SIZE;
         if (messageLength == 0) {
             // Zero-sized frame: just ignore it and return nothing
             buffer.readerIndex(messageContentsOffset);
             return null;
-        }
-        else if (buffer.readableBytes() < messageLength) {
+        } else if (buffer.readableBytes() < messageLength) {
             // Full message isn't available yet, return nothing for now
             return null;
-        }
-        else {
+        } else {
             // Full message is available, return it
             ChannelBuffer messageBuffer = extractFrame(buffer,
                                                        messageContentsOffset,
                                                        messageContentsLength);
             buffer.readerIndex(messageStartReaderIndex + messageLength);
-            return new TNiftyTransport(channel, messageBuffer, ThriftTransportType.FRAMED);
+            return messageBuffer;
         }
     }
 
-    private TTransport tryDecodeUnframedMessage(ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer)
-            throws TException {
+    protected ChannelBuffer tryDecodeUnframedMessage(ChannelHandlerContext ctx,
+                                                     Channel channel,
+                                                     ChannelBuffer buffer,
+                                                     TProtocolFactory inputProtocolFactory)
+            throws TException
+    {
         // Perform a trial decode, skipping through
         // the fields, to see whether we have an entire message available.
 
@@ -111,7 +128,7 @@ public class ThriftFrameDecoder extends FrameDecoder {
             TNiftyTransport decodeAttemptTransport =
                     new TNiftyTransport(channel, buffer, ThriftTransportType.UNFRAMED);
             TProtocol inputProtocol =
-                    this.inputProtocolFactory.getProtocol(decodeAttemptTransport);
+                    inputProtocolFactory.getProtocol(decodeAttemptTransport);
 
             // Skip through the message
             inputProtocol.readMessageBegin();
@@ -126,8 +143,7 @@ public class ThriftFrameDecoder extends FrameDecoder {
             if (buffer.readerIndex() - messageStartReaderIndex > maxFrameSize) {
                 Channels.fireExceptionCaught(
                         ctx,
-                        new TooLongFrameException("Maximum frame size of " + maxFrameSize +
-                                                  " exceeded")
+                        new TooLongFrameException("Maximum frame size of " + maxFrameSize + " exceeded")
                 );
             }
 
@@ -142,10 +158,11 @@ public class ThriftFrameDecoder extends FrameDecoder {
         ChannelBuffer messageBuffer =
                 extractFrame(buffer, messageStartReaderIndex, messageLength);
         buffer.readerIndex(messageStartReaderIndex + messageLength);
-        return new TNiftyTransport(channel, messageBuffer, ThriftTransportType.UNFRAMED);
+        return messageBuffer;
     }
 
-    protected ChannelBuffer extractFrame(ChannelBuffer buffer, int index, int length) {
+    protected ChannelBuffer extractFrame(ChannelBuffer buffer, int index, int length)
+    {
         // Slice should be sufficient here (and avoids the copy in LengthFieldBasedFrameDecoder)
         // because we know no one is going to modify the contents in the read buffers.
         return buffer.slice(index, length);

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameEncoder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/DefaultThriftFrameEncoder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import com.facebook.nifty.core.ThriftMessage;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+
+public class DefaultThriftFrameEncoder extends ThriftFrameEncoder
+{
+    private final long maxFrameSize;
+
+    public DefaultThriftFrameEncoder(long maxFrameSize)
+    {
+
+        this.maxFrameSize = maxFrameSize;
+    }
+
+    @Override
+    protected ChannelBuffer encode(ChannelHandlerContext ctx,
+                                   Channel channel,
+                                   ThriftMessage message) throws Exception
+    {
+        if (message.getBuffer().readableBytes() > maxFrameSize)
+        {
+            Channels.fireExceptionCaught(ctx, new TooLongFrameException("Frame size exceeded on encode"));
+            return ChannelBuffers.EMPTY_BUFFER;
+        }
+
+        switch (message.getTransportType()) {
+            case UNFRAMED:
+                return message.getBuffer();
+
+            case FRAMED:
+                ChannelBuffer frameSizeBuffer = ChannelBuffers.buffer(4);
+                frameSizeBuffer.writeInt(message.getBuffer().readableBytes());
+                return ChannelBuffers.wrappedBuffer(frameSizeBuffer, message.getBuffer());
+
+            case HEADER:
+                throw new UnsupportedOperationException("Header transport is not supported");
+
+            default:
+                throw new UnsupportedOperationException("Unrecognized transport type");
+        }
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameCodec.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameCodec.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import org.jboss.netty.channel.ChannelDownstreamHandler;
+import org.jboss.netty.channel.ChannelUpstreamHandler;
+
+public interface ThriftFrameCodec extends ChannelUpstreamHandler, ChannelDownstreamHandler
+{
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameCodecFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameCodecFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.jboss.netty.channel.ChannelHandler;
+
+public interface ThriftFrameCodecFactory
+{
+    public ChannelHandler create(int maxFrameSize, TProtocolFactory defaultProtocolFactory);
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameDecoder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameDecoder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import com.facebook.nifty.core.ThriftMessage;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.frame.FrameDecoder;
+
+public abstract class ThriftFrameDecoder extends FrameDecoder
+{
+    protected abstract ThriftMessage decode(ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer)
+            throws Exception;
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameEncoder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/codec/ThriftFrameEncoder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.codec;
+
+import com.facebook.nifty.core.ThriftMessage;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.oneone.OneToOneEncoder;
+
+public abstract class ThriftFrameEncoder extends OneToOneEncoder
+{
+    protected abstract ChannelBuffer encode(ChannelHandlerContext ctx, Channel channel, ThriftMessage message)
+            throws Exception;
+
+    protected Object encode(ChannelHandlerContext ctx, Channel channel, Object message)
+            throws Exception
+    {
+        if (!(message instanceof ThriftMessage)) {
+            return message;
+        }
+
+        return encode(ctx, channel, (ThriftMessage) message);
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.nifty.core;
 
+import org.apache.thrift.protocol.TProtocolFactory;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
@@ -71,9 +72,10 @@ public class NettyServerTransport implements ExternalResourceReleasable
                     throws Exception
             {
                 ChannelPipeline cp = Channels.pipeline();
+                TProtocolFactory inputProtocolFactory = def.getDuplexProtocolFactory().getInputProtocolFactory();
                 cp.addLast(ChannelStatistics.NAME, new ChannelStatistics(allChannels));
                 cp.addLast("frameCodec", def.getThriftFrameCodecFactory().create(def.getMaxFrameSize(),
-                                                                                 def.getInProtocolFactory()));
+                                                                                 inputProtocolFactory));
                 if (def.getClientIdleTimeout() != null) {
                     // Add handlers to detect idle client connections and disconnect them
                     cp.addLast("idleTimeoutHandler", new IdleStateHandler(timer,

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -25,6 +25,7 @@ import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.Channels;
 import org.jboss.netty.channel.ServerChannelFactory;
 import org.jboss.netty.channel.group.ChannelGroup;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.jboss.netty.handler.timeout.IdleStateHandler;
 import org.jboss.netty.util.ExternalResourceReleasable;
 import org.jboss.netty.util.Timer;
@@ -90,6 +91,16 @@ public class NettyServerTransport implements ExternalResourceReleasable
                 return cp;
             }
         };
+    }
+
+    public void start()
+    {
+        start(new NioServerSocketChannelFactory());
+    }
+
+    public void start(ExecutorService bossExecutor, ExecutorService ioWorkerExecutor)
+    {
+        start(new NioServerSocketChannelFactory(bossExecutor, ioWorkerExecutor));
     }
 
     public void start(ServerChannelFactory serverChannelFactory)

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -75,8 +75,8 @@ public class NettyServerTransport implements ExternalResourceReleasable
                 {
                     ChannelPipeline cp = Channels.pipeline();
                     cp.addLast(ChannelStatistics.NAME, new ChannelStatistics(allChannels));
-                    cp.addLast("frameDecoder", new ThriftFrameDecoder(def.getMaxFrameSize(),
-                                                                      def.getInProtocolFactory()));
+                    cp.addLast("frameCodec", def.getThriftFrameCodecFactory().create(def.getMaxFrameSize(),
+                                                                                     def.getInProtocolFactory()));
                     if (def.getClientIdleTimeout() != null) {
                         // Add handlers to detect idle client connections and disconnect them
                         cp.addLast("idleTimeoutHandler", new IdleStateHandler(timer,

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -63,36 +63,31 @@ public class NettyServerTransport implements ExternalResourceReleasable
         this.def = def;
         this.configBuilder = configBuilder;
         this.port = def.getServerPort();
-        if (def.isHeaderTransport()) {
-            throw new UnsupportedOperationException("ASF version does not support THeaderTransport !");
-        }
-        else {
-            this.pipelineFactory = new ChannelPipelineFactory()
-            {
-                @Override
-                public ChannelPipeline getPipeline()
-                        throws Exception
-                {
-                    ChannelPipeline cp = Channels.pipeline();
-                    cp.addLast(ChannelStatistics.NAME, new ChannelStatistics(allChannels));
-                    cp.addLast("frameCodec", def.getThriftFrameCodecFactory().create(def.getMaxFrameSize(),
-                                                                                     def.getInProtocolFactory()));
-                    if (def.getClientIdleTimeout() != null) {
-                        // Add handlers to detect idle client connections and disconnect them
-                        cp.addLast("idleTimeoutHandler", new IdleStateHandler(timer,
-                                                                              (int)def.getClientIdleTimeout().toMillis(),
-                                                                              NO_WRITER_IDLE_TIMEOUT,
-                                                                              NO_ALL_IDLE_TIMEOUT,
-                                                                              TimeUnit.MILLISECONDS
-                                                                              ));
-                        cp.addLast("idleDisconnectHandler", new IdleDisconnectHandler());
-                    }
-                    cp.addLast("dispatcher", new NiftyDispatcher(def));
-                    return cp;
-                }
-            };
-        }
 
+        this.pipelineFactory = new ChannelPipelineFactory()
+        {
+            @Override
+            public ChannelPipeline getPipeline()
+                    throws Exception
+            {
+                ChannelPipeline cp = Channels.pipeline();
+                cp.addLast(ChannelStatistics.NAME, new ChannelStatistics(allChannels));
+                cp.addLast("frameCodec", def.getThriftFrameCodecFactory().create(def.getMaxFrameSize(),
+                                                                                 def.getInProtocolFactory()));
+                if (def.getClientIdleTimeout() != null) {
+                    // Add handlers to detect idle client connections and disconnect them
+                    cp.addLast("idleTimeoutHandler", new IdleStateHandler(timer,
+                                                                          (int)def.getClientIdleTimeout().toMillis(),
+                                                                          NO_WRITER_IDLE_TIMEOUT,
+                                                                          NO_ALL_IDLE_TIMEOUT,
+                                                                          TimeUnit.MILLISECONDS
+                                                                          ));
+                    cp.addLast("idleDisconnectHandler", new IdleDisconnectHandler());
+                }
+                cp.addLast("dispatcher", new NiftyDispatcher(def));
+                return cp;
+            }
+        };
     }
 
     public void start(ServerChannelFactory serverChannelFactory)

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
@@ -15,6 +15,9 @@
  */
 package com.facebook.nifty.core;
 
+import com.facebook.nifty.duplex.TDuplexProtocolFactory;
+import com.facebook.nifty.duplex.TProtocolPair;
+import com.facebook.nifty.duplex.TTransportPair;
 import com.facebook.nifty.processor.NiftyProcessorFactory;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
@@ -46,19 +49,17 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
     private static final Logger log = LoggerFactory.getLogger(NiftyDispatcher.class);
 
     private final NiftyProcessorFactory processorFactory;
-    private final TProtocolFactory inProtocolFactory;
-    private final TProtocolFactory outProtocolFactory;
     private final Executor exe;
     private final int queuedResponseLimit;
     private final Map<Integer, ThriftMessage> responseMap = new HashMap<>();
     private final AtomicInteger dispatcherSequenceId = new AtomicInteger(0);
     private final AtomicInteger lastResponseWrittenId = new AtomicInteger(0);
+    private final TDuplexProtocolFactory duplexProtocolFactory;
 
     public NiftyDispatcher(ThriftServerDef def)
     {
         this.processorFactory = def.getProcessorFactory();
-        this.inProtocolFactory = def.getInProtocolFactory();
-        this.outProtocolFactory = def.getOutProtocolFactory();
+        this.duplexProtocolFactory = def.getDuplexProtocolFactory();
         this.queuedResponseLimit = def.getQueuedResponseLimit();
         this.exe = def.getExecutor();
     }
@@ -104,8 +105,11 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
             @Override
             public void run()
             {
-                TProtocol inProtocol = inProtocolFactory.getProtocol(messageTransport);
-                TProtocol outProtocol = outProtocolFactory.getProtocol(messageTransport);
+                TTransportPair transportPair = TTransportPair.fromSingleTransport(messageTransport);
+                TProtocolPair protocolPair = duplexProtocolFactory.getProtocolPair(transportPair);
+                TProtocol inProtocol = protocolPair.getInputProtocol();
+                TProtocol outProtocol = protocolPair.getOutputProtocol();
+
                 try {
                     RequestContext requestContext = new RequestContext(ctx.getChannel().getRemoteAddress());
                     processorFactory.getProcessor(messageTransport).process(inProtocol, outProtocol, requestContext);

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
@@ -15,12 +15,10 @@
  */
 package com.facebook.nifty.core;
 
+import com.facebook.nifty.processor.NiftyProcessorFactory;
 import org.apache.thrift.TException;
-import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.channel.Channels;
@@ -47,7 +45,7 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
 {
     private static final Logger log = LoggerFactory.getLogger(NiftyDispatcher.class);
 
-    private final TProcessorFactory processorFactory;
+    private final NiftyProcessorFactory processorFactory;
     private final TProtocolFactory inProtocolFactory;
     private final TProtocolFactory outProtocolFactory;
     private final Executor exe;
@@ -109,10 +107,8 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
                 TProtocol inProtocol = inProtocolFactory.getProtocol(messageTransport);
                 TProtocol outProtocol = outProtocolFactory.getProtocol(messageTransport);
                 try {
-                    processorFactory.getProcessor(messageTransport).process(
-                            inProtocol,
-                            outProtocol
-                    );
+                    RequestContext requestContext = new RequestContext(ctx.getChannel().getRemoteAddress());
+                    processorFactory.getProcessor(messageTransport).process(inProtocol, outProtocol, requestContext);
                     writeResponse(ctx, messageTransport, requestSequenceId);
                 }
                 catch (TException e1) {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
@@ -52,7 +52,7 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
     private final TProtocolFactory outProtocolFactory;
     private final Executor exe;
     private final int queuedResponseLimit;
-    private final Map<Integer, ChannelBuffer> responseMap = new HashMap<Integer, ChannelBuffer>();
+    private final Map<Integer, ThriftMessage> responseMap = new HashMap<>();
     private final AtomicInteger dispatcherSequenceId = new AtomicInteger(0);
     private final AtomicInteger lastResponseWrittenId = new AtomicInteger(0);
 
@@ -69,8 +69,11 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
     public void messageReceived(ChannelHandlerContext ctx, final MessageEvent e)
             throws Exception
     {
-        if (e.getMessage() instanceof TNiftyTransport) {
-            TNiftyTransport messageTransport = (TNiftyTransport) e.getMessage();
+        if (e.getMessage() instanceof ThriftMessage) {
+            ThriftMessage message = (ThriftMessage) e.getMessage();
+            TNiftyTransport messageTransport = new TNiftyTransport(ctx.getChannel(),
+                                                                   message.getBuffer(),
+                                                                   message.getTransportType());
             processRequest(ctx, messageTransport);
         }
         else {
@@ -127,24 +130,23 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
         // Ensure responses to requests are written in the same order the requests
         // were received.
         synchronized (responseMap) {
-            ChannelBuffer response = messageTransport.getOutputBuffer();
-            ThriftTransportType transportType = messageTransport.getTransportType();
+            ThriftMessage thriftMessage = new ThriftMessage(messageTransport.getOutputBuffer(),
+                                                            messageTransport.getTransportType());
             int currentResponseId = lastResponseWrittenId.get() + 1;
             if (responseSequenceId != currentResponseId) {
                 // This response is NOT next in line of ordered responses, save it to
                 // be sent later, after responses to all earlier requests have been
                 // sent.
-                responseMap.put(responseSequenceId, response);
+                responseMap.put(responseSequenceId, thriftMessage);
             } else {
                 // This response was next in line, write this response now, and see if
                 // there are others next in line that should be sent now as well.
                 do {
-                    response = addFraming(response, transportType);
-                    Channels.write(ctx.getChannel(), response);
+                    Channels.write(ctx.getChannel(), thriftMessage);
                     lastResponseWrittenId.incrementAndGet();
                     ++currentResponseId;
-                    response = responseMap.remove(currentResponseId);
-                } while (null != response);
+                    thriftMessage = responseMap.remove(currentResponseId);
+                } while (null != thriftMessage);
 
                 // Now that we've written some responses, check if reads should be unblocked
                 if (isChannelReadBlocked(ctx)) {
@@ -154,20 +156,6 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
                     }
                 }
             }
-        }
-    }
-
-    private ChannelBuffer addFraming(ChannelBuffer response, ThriftTransportType transportType) {
-        if (transportType == ThriftTransportType.UNFRAMED) {
-            return response;
-        }
-        else if (transportType == ThriftTransportType.FRAMED) {
-            ChannelBuffer frameSizeBuffer = ChannelBuffers.buffer(4);
-            frameSizeBuffer.writeInt(response.readableBytes());
-            return ChannelBuffers.wrappedBuffer(frameSizeBuffer, response);
-        }
-        else {
-            throw new UnsupportedOperationException("Header protocol is not supported");
         }
     }
 

--- a/nifty-core/src/main/java/com/facebook/nifty/core/RequestContext.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/RequestContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import java.net.SocketAddress;
+
+public class RequestContext
+{
+    private final SocketAddress remoteAddress;
+
+    public RequestContext(SocketAddress remoteAddress)
+    {
+        this.remoteAddress = remoteAddress;
+    }
+
+    public SocketAddress getRemoteAddress()
+    {
+        return remoteAddress;
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftMessage.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftMessage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+public class ThriftMessage
+{
+    private ChannelBuffer buffer;
+    private ThriftTransportType transportType;
+
+    public ThriftMessage(ChannelBuffer buffer, ThriftTransportType transportType)
+    {
+        this.buffer = buffer;
+        this.transportType = transportType;
+    }
+
+    public ChannelBuffer getBuffer()
+    {
+        return buffer;
+    }
+
+    public ThriftTransportType getTransportType()
+    {
+        return transportType;
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.nifty.core;
 
+import com.facebook.nifty.codec.ThriftFrameCodecFactory;
 import io.airlift.units.Duration;
 import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TProtocolFactory;
@@ -36,8 +37,10 @@ public class ThriftServerDef
     private final Duration clientIdleTimeout;
 
     private final boolean headerTransport;
+    private final ThriftFrameCodecFactory thriftFrameCodecFactory;
     private final Executor executor;
     private final String name;
+
     public ThriftServerDef(
             String name,
             int serverPort,
@@ -48,6 +51,7 @@ public class ThriftServerDef
             TProtocolFactory outProtocolFact,
             Duration clientIdleTimeout,
             boolean useHeaderTransport,
+            ThriftFrameCodecFactory thriftFrameCodecFactory,
             Executor executor)
     {
         this.name = name;
@@ -59,6 +63,7 @@ public class ThriftServerDef
         this.outProtocolFact = outProtocolFact;
         this.clientIdleTimeout = clientIdleTimeout;
         this.headerTransport = useHeaderTransport;
+        this.thriftFrameCodecFactory = thriftFrameCodecFactory;
         this.executor = executor;
     }
 
@@ -114,5 +119,10 @@ public class ThriftServerDef
     public String getName()
     {
         return name;
+    }
+
+    public ThriftFrameCodecFactory getThriftFrameCodecFactory()
+    {
+        return thriftFrameCodecFactory;
     }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -36,7 +36,6 @@ public class ThriftServerDef
 
     private final Duration clientIdleTimeout;
 
-    private final boolean headerTransport;
     private final ThriftFrameCodecFactory thriftFrameCodecFactory;
     private final Executor executor;
     private final String name;
@@ -50,7 +49,6 @@ public class ThriftServerDef
             TProtocolFactory inProtocolFact,
             TProtocolFactory outProtocolFact,
             Duration clientIdleTimeout,
-            boolean useHeaderTransport,
             ThriftFrameCodecFactory thriftFrameCodecFactory,
             Executor executor)
     {
@@ -62,7 +60,6 @@ public class ThriftServerDef
         this.inProtocolFact = inProtocolFact;
         this.outProtocolFact = outProtocolFact;
         this.clientIdleTimeout = clientIdleTimeout;
-        this.headerTransport = useHeaderTransport;
         this.thriftFrameCodecFactory = thriftFrameCodecFactory;
         this.executor = executor;
     }
@@ -104,11 +101,6 @@ public class ThriftServerDef
 
     public Duration getClientIdleTimeout() {
         return clientIdleTimeout;
-    }
-
-    public boolean isHeaderTransport()
-    {
-        return headerTransport;
     }
 
     public Executor getExecutor()

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -16,9 +16,9 @@
 package com.facebook.nifty.core;
 
 import com.facebook.nifty.codec.ThriftFrameCodecFactory;
+import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.facebook.nifty.processor.NiftyProcessorFactory;
 import io.airlift.units.Duration;
-import org.apache.thrift.protocol.TProtocolFactory;
 
 import java.util.concurrent.Executor;
 
@@ -31,8 +31,7 @@ public class ThriftServerDef
     private final int maxFrameSize;
     private final int queuedResponseLimit;
     private final NiftyProcessorFactory processorFactory;
-    private final TProtocolFactory inProtocolFact;
-    private final TProtocolFactory outProtocolFact;
+    private final TDuplexProtocolFactory duplexProtocolFactory;
 
     private final Duration clientIdleTimeout;
 
@@ -46,8 +45,7 @@ public class ThriftServerDef
             int maxFrameSize,
             int queuedResponseLimit,
             NiftyProcessorFactory processorFactory,
-            TProtocolFactory inProtocolFact,
-            TProtocolFactory outProtocolFact,
+            TDuplexProtocolFactory duplexProtocolFactory,
             Duration clientIdleTimeout,
             ThriftFrameCodecFactory thriftFrameCodecFactory,
             Executor executor)
@@ -57,8 +55,7 @@ public class ThriftServerDef
         this.maxFrameSize = maxFrameSize;
         this.queuedResponseLimit = queuedResponseLimit;
         this.processorFactory = processorFactory;
-        this.inProtocolFact = inProtocolFact;
-        this.outProtocolFact = outProtocolFact;
+        this.duplexProtocolFactory = duplexProtocolFactory;
         this.clientIdleTimeout = clientIdleTimeout;
         this.thriftFrameCodecFactory = thriftFrameCodecFactory;
         this.executor = executor;
@@ -89,14 +86,9 @@ public class ThriftServerDef
         return processorFactory;
     }
 
-    public TProtocolFactory getInProtocolFactory()
+    public TDuplexProtocolFactory getDuplexProtocolFactory()
     {
-        return inProtocolFact;
-    }
-
-    public TProtocolFactory getOutProtocolFactory()
-    {
-        return outProtocolFact;
+        return duplexProtocolFactory;
     }
 
     public Duration getClientIdleTimeout() {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -16,8 +16,8 @@
 package com.facebook.nifty.core;
 
 import com.facebook.nifty.codec.ThriftFrameCodecFactory;
+import com.facebook.nifty.processor.NiftyProcessorFactory;
 import io.airlift.units.Duration;
-import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TProtocolFactory;
 
 import java.util.concurrent.Executor;
@@ -30,7 +30,7 @@ public class ThriftServerDef
     private final int serverPort;
     private final int maxFrameSize;
     private final int queuedResponseLimit;
-    private final TProcessorFactory processorFactory;
+    private final NiftyProcessorFactory processorFactory;
     private final TProtocolFactory inProtocolFact;
     private final TProtocolFactory outProtocolFact;
 
@@ -46,7 +46,7 @@ public class ThriftServerDef
             int serverPort,
             int maxFrameSize,
             int queuedResponseLimit,
-            TProcessorFactory factory,
+            NiftyProcessorFactory processorFactory,
             TProtocolFactory inProtocolFact,
             TProtocolFactory outProtocolFact,
             Duration clientIdleTimeout,
@@ -58,7 +58,7 @@ public class ThriftServerDef
         this.serverPort = serverPort;
         this.maxFrameSize = maxFrameSize;
         this.queuedResponseLimit = queuedResponseLimit;
-        this.processorFactory = factory;
+        this.processorFactory = processorFactory;
         this.inProtocolFact = inProtocolFact;
         this.outProtocolFact = outProtocolFact;
         this.clientIdleTimeout = clientIdleTimeout;
@@ -87,7 +87,7 @@ public class ThriftServerDef
         return queuedResponseLimit;
     }
 
-    public TProcessorFactory getProcessorFactory()
+    public NiftyProcessorFactory getProcessorFactory()
     {
         return processorFactory;
     }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
@@ -17,14 +17,21 @@ package com.facebook.nifty.core;
 
 import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
 import com.facebook.nifty.codec.ThriftFrameCodecFactory;
+import com.facebook.nifty.processor.NiftyProcessor;
+import com.facebook.nifty.processor.NiftyProcessorFactory;
 import io.airlift.units.Duration;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.TProcessorFactory;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.TTransport;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.nifty.processor.NiftyProcessorAdapters.factoryFromTProcessor;
+import static com.facebook.nifty.processor.NiftyProcessorAdapters.factoryFromTProcessorFactory;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Builder for the Thrift Server descriptor. Example :
@@ -48,9 +55,10 @@ public class ThriftServerDefBuilder
     private int serverPort;
     private int maxFrameSize;
     private int queuedResponseLimit;
-    private TProcessorFactory processorFactory;
     private TProtocolFactory inProtocolFact;
     private TProtocolFactory outProtocolFact;
+    private NiftyProcessorFactory niftyProcessorFactory;
+    private TProcessorFactory thriftProcessorFactory;
     private Executor executor;
     private String name = "nifty-" + ID.getAndIncrement();
     private boolean useHeaderTransport;
@@ -76,7 +84,7 @@ public class ThriftServerDefBuilder
         };
         this.useHeaderTransport = false;
         this.clientIdleTimeout = null;
-        this.thriftFrameCodecFactory = new DefaulThriftFrameCodecFactory();
+        this.thriftFrameCodecFactory = new DefaultThriftFrameCodecFactory();
     }
 
     /**
@@ -110,9 +118,39 @@ public class ThriftServerDefBuilder
     /**
      * Specify the TProcessor.
      */
-    public ThriftServerDefBuilder withProcessor(TProcessor p)
+    public ThriftServerDefBuilder withProcessor(final NiftyProcessor processor)
     {
-        this.processorFactory = new TProcessorFactory(p);
+        this.niftyProcessorFactory = new NiftyProcessorFactory() {
+            @Override
+            public NiftyProcessor getProcessor(TTransport transport)
+            {
+                return processor;
+            }
+        };
+        return this;
+    }
+
+    public ThriftServerDefBuilder withProcessor(final TProcessor processor)
+    {
+        this.thriftProcessorFactory = new TProcessorFactory(processor);
+        return this;
+    }
+
+    /**
+     * Anohter way to specify the TProcessor.
+     */
+    public ThriftServerDefBuilder withProcessorFactory(NiftyProcessorFactory processorFactory)
+    {
+        this.niftyProcessorFactory = processorFactory;
+        return this;
+    }
+
+    /**
+     * Anohter way to specify the TProcessor.
+     */
+    public ThriftServerDefBuilder withProcessorFactory(TProcessorFactory processorFactory)
+    {
+        this.thriftProcessorFactory = processorFactory;
         return this;
     }
 
@@ -132,15 +170,6 @@ public class ThriftServerDefBuilder
     public ThriftServerDefBuilder limitQueuedResponsesPerConnection(int queuedResponseLimit)
     {
         this.queuedResponseLimit = queuedResponseLimit;
-        return this;
-    }
-
-    /**
-     * Anohter way to specify the TProcessor.
-     */
-    public ThriftServerDefBuilder withProcessorFactory(TProcessorFactory processorFactory)
-    {
-        this.processorFactory = processorFactory;
         return this;
     }
 
@@ -205,17 +234,24 @@ public class ThriftServerDefBuilder
      */
     public ThriftServerDef build()
     {
-        if (processorFactory == null) {
-            throw new IllegalStateException("processor not defined !");
+        checkState(niftyProcessorFactory != null || thriftProcessorFactory != null,
+                   "Processor not defined!");
+        checkState(niftyProcessorFactory == null || thriftProcessorFactory == null,
+                   "TProcessors will be automatically adapted to NiftyProcessors, don't specify both");
+
+        if (niftyProcessorFactory == null)
+        {
+            niftyProcessorFactory = factoryFromTProcessorFactory(thriftProcessorFactory);
         }
+
         return new ThriftServerDef(
                 name,
                 serverPort,
                 maxFrameSize,
                 queuedResponseLimit,
-                processorFactory,
                 inProtocolFact,
                 outProtocolFact,
+                niftyProcessorFactory,
                 clientIdleTimeout,
                 useHeaderTransport,
                 thriftFrameCodecFactory,

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
@@ -17,6 +17,7 @@ package com.facebook.nifty.core;
 
 import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
 import com.facebook.nifty.codec.ThriftFrameCodecFactory;
+import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.facebook.nifty.processor.NiftyProcessor;
 import com.facebook.nifty.processor.NiftyProcessorFactory;
 import io.airlift.units.Duration;
@@ -55,10 +56,9 @@ public class ThriftServerDefBuilder
     private int serverPort;
     private int maxFrameSize;
     private int queuedResponseLimit;
-    private TProtocolFactory inProtocolFact;
-    private TProtocolFactory outProtocolFact;
     private NiftyProcessorFactory niftyProcessorFactory;
     private TProcessorFactory thriftProcessorFactory;
+    private TDuplexProtocolFactory duplexProtocolFactory;
     private Executor executor;
     private String name = "nifty-" + ID.getAndIncrement();
     private Duration clientIdleTimeout;
@@ -71,8 +71,7 @@ public class ThriftServerDefBuilder
         this.serverPort = 8080;
         this.maxFrameSize = 1048576;
         this.queuedResponseLimit = 16;
-        this.inProtocolFact = new TBinaryProtocol.Factory();
-        this.outProtocolFact = new TBinaryProtocol.Factory();
+        this.duplexProtocolFactory = TDuplexProtocolFactory.fromSingleFactory(new TBinaryProtocol.Factory());
         this.executor = new Executor()
         {
             @Override
@@ -106,10 +105,15 @@ public class ThriftServerDefBuilder
     /**
      * Specify protocolFactory for both input and output
      */
+    public ThriftServerDefBuilder speaks(TDuplexProtocolFactory tProtocolFactory)
+    {
+        this.duplexProtocolFactory = tProtocolFactory;
+        return this;
+    }
+
     public ThriftServerDefBuilder speaks(TProtocolFactory tProtocolFactory)
     {
-        this.inProtocolFact = tProtocolFactory;
-        this.outProtocolFact = tProtocolFactory;
+        this.duplexProtocolFactory = TDuplexProtocolFactory.fromSingleFactory(tProtocolFactory);
         return this;
     }
 
@@ -172,24 +176,6 @@ public class ThriftServerDefBuilder
     }
 
     /**
-     * Specify only the input protocol.
-     */
-    public ThriftServerDefBuilder inProtocol(TProtocolFactory tProtocolFactory)
-    {
-        this.inProtocolFact = tProtocolFactory;
-        return this;
-    }
-
-    /**
-     * Specify only the output protocol.
-     */
-    public ThriftServerDefBuilder outProtocol(TProtocolFactory tProtocolFactory)
-    {
-        this.outProtocolFact = tProtocolFactory;
-        return this;
-    }
-
-    /**
      * Specify timeout during which if connected client doesn't send a message, server
      * will disconnect the client
      */
@@ -241,9 +227,8 @@ public class ThriftServerDefBuilder
                 serverPort,
                 maxFrameSize,
                 queuedResponseLimit,
-                inProtocolFact,
-                outProtocolFact,
                 niftyProcessorFactory,
+                duplexProtocolFactory,
                 clientIdleTimeout,
                 thriftFrameCodecFactory,
                 executor);

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
@@ -61,7 +61,6 @@ public class ThriftServerDefBuilder
     private TProcessorFactory thriftProcessorFactory;
     private Executor executor;
     private String name = "nifty-" + ID.getAndIncrement();
-    private boolean useHeaderTransport;
     private Duration clientIdleTimeout;
 
     /**
@@ -82,7 +81,6 @@ public class ThriftServerDefBuilder
                 runnable.run();
             }
         };
-        this.useHeaderTransport = false;
         this.clientIdleTimeout = null;
         this.thriftFrameCodecFactory = new DefaultThriftFrameCodecFactory();
     }
@@ -223,12 +221,6 @@ public class ThriftServerDefBuilder
         return this;
     }
 
-    public ThriftServerDefBuilder usingHeaderTransport()
-    {
-        this.useHeaderTransport = true;
-        return this;
-    }
-
     /**
      * Build the ThriftServerDef
      */
@@ -253,7 +245,6 @@ public class ThriftServerDefBuilder
                 outProtocolFact,
                 niftyProcessorFactory,
                 clientIdleTimeout,
-                useHeaderTransport,
                 thriftFrameCodecFactory,
                 executor);
     }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilder.java
@@ -15,6 +15,8 @@
  */
 package com.facebook.nifty.core;
 
+import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
+import com.facebook.nifty.codec.ThriftFrameCodecFactory;
 import io.airlift.units.Duration;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.TProcessorFactory;
@@ -42,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ThriftServerDefBuilder
 {
     private static final AtomicInteger ID = new AtomicInteger(1);
+    private ThriftFrameCodecFactory thriftFrameCodecFactory;
     private int serverPort;
     private int maxFrameSize;
     private int queuedResponseLimit;
@@ -73,6 +76,7 @@ public class ThriftServerDefBuilder
         };
         this.useHeaderTransport = false;
         this.clientIdleTimeout = null;
+        this.thriftFrameCodecFactory = new DefaulThriftFrameCodecFactory();
     }
 
     /**
@@ -169,6 +173,17 @@ public class ThriftServerDefBuilder
     }
 
     /**
+     * Set the frame
+     *
+     * @param thriftFrameCodecFactory
+     */
+    public ThriftServerDefBuilder thriftFrameCodecFactory(ThriftFrameCodecFactory thriftFrameCodecFactory)
+    {
+        this.thriftFrameCodecFactory = thriftFrameCodecFactory;
+        return this;
+    }
+
+    /**
      * Specify an executor for thrift processor invocations ( i.e. = THaHsServer )
      * By default invocation happens in Netty single thread
      * ( i.e. = TNonBlockingServer )
@@ -203,6 +218,7 @@ public class ThriftServerDefBuilder
                 outProtocolFact,
                 clientIdleTimeout,
                 useHeaderTransport,
+                thriftFrameCodecFactory,
                 executor);
     }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/duplex/TDuplexProtocolFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/duplex/TDuplexProtocolFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.duplex;
+
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.TTransport;
+
+/***
+ * A factory for creating a pair of protocols (one for input, one for output). Gives more
+ * flexibility to the factory to enforce protocol restrictions (e.g. header protocol requires
+ * the input/output transport/protocol are the same, a duplex header protocol factory can enforce
+ * the transport restriction because it can see both transports, and can guarantee both protocols
+ * are the same because it can fill in the input/output slots of the protocol pair with the same
+ * protocol object).
+ */
+public abstract class TDuplexProtocolFactory {
+    public abstract TProtocolPair getProtocolPair(TTransportPair transportPair);
+
+    public TProtocolFactory getInputProtocolFactory()
+    {
+        return new TProtocolFactory()
+        {
+            @Override
+            public TProtocol getProtocol(TTransport trans)
+            {
+                return getProtocolPair(TTransportPair.fromSingleTransport(trans)).getInputProtocol();
+            }
+        };
+    }
+
+    public TProtocolFactory getOutputProtocolFactory()
+    {
+        return new TProtocolFactory()
+        {
+            @Override
+            public TProtocol getProtocol(TTransport trans)
+            {
+                return getProtocolPair(TTransportPair.fromSingleTransport(trans)).getOutputProtocol();
+            }
+        };
+    }
+
+    public static TDuplexProtocolFactory fromSingleFactory(
+            final TProtocolFactory protocolFactory
+    )
+    {
+        return new TDuplexProtocolFactory() {
+            @Override
+            public TProtocolPair getProtocolPair(TTransportPair transportPair) {
+                return TProtocolPair.fromSeparateProtocols(
+                        protocolFactory.getProtocol(transportPair.getInputTransport()),
+                        protocolFactory.getProtocol(transportPair.getOutputTransport()));
+            }
+        };
+    }
+
+    public static TDuplexProtocolFactory fromSeparateFactories(
+            final TProtocolFactory inputProtocolFactory,
+            final TProtocolFactory outputProtocolFactory
+    )
+    {
+        return new TDuplexProtocolFactory() {
+            @Override
+            public TProtocolPair getProtocolPair(TTransportPair transportPair) {
+                return TProtocolPair.fromSeparateProtocols(
+                        inputProtocolFactory.getProtocol(transportPair.getInputTransport()),
+                        outputProtocolFactory.getProtocol(transportPair.getOutputTransport())
+                );
+            }
+        };
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/duplex/TDuplexTransportFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/duplex/TDuplexTransportFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.duplex;
+
+import org.apache.thrift.transport.TTransportFactory;
+
+/***
+ * A factory for creating a pair of protocols (one for input, one for output). Gives more
+ * flexibility to the factory to enforce protocol restrictions. See {@link TDuplexProtocolFactory}
+ * documentation for more details.
+ */
+public abstract class TDuplexTransportFactory {
+    public abstract TTransportPair getTransportPair(TTransportPair transportPair);
+
+    public static TDuplexTransportFactory fromSingleTransportFactory(
+            final TTransportFactory transportFactory
+    )
+    {
+        return new TDuplexTransportFactory() {
+            @Override
+            public TTransportPair getTransportPair(TTransportPair transportPair) {
+                return TTransportPair.fromSeparateTransports(
+                        transportFactory.getTransport(transportPair.getInputTransport()),
+                        transportFactory.getTransport(transportPair.getOutputTransport()));
+            }
+        };
+    }
+
+    public static TDuplexTransportFactory fromSeparateTransportFactories(
+            final TTransportFactory inputTransportFactory,
+            final TTransportFactory outputTransportFactory
+    )
+    {
+        return new TDuplexTransportFactory() {
+            @Override
+            public TTransportPair getTransportPair(TTransportPair transportPair) {
+                return TTransportPair.fromSeparateTransports(
+                        inputTransportFactory.getTransport(transportPair.getInputTransport()),
+                        outputTransportFactory.getTransport(transportPair.getOutputTransport())
+                );
+            }
+        };
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/duplex/TProtocolPair.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/duplex/TProtocolPair.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.duplex;
+
+import org.apache.thrift.protocol.TProtocol;
+
+/***
+ * An interface for representing a pair of protocols: one for input and one for output,
+ * and utility functions for creating a pair instance from a single protocol or from
+ * separate input and output protocols.
+ */
+public abstract class TProtocolPair {
+    public abstract TProtocol getInputProtocol();
+    public abstract TProtocol getOutputProtocol();
+
+    public static TProtocolPair fromSeparateProtocols(final TProtocol inputProtocol,
+                                                      final TProtocol outputProtocol) {
+        return new TProtocolPair() {
+            @Override
+            public TProtocol getInputProtocol() {
+                return inputProtocol;
+            }
+
+            @Override
+            public TProtocol getOutputProtocol() {
+                return outputProtocol;
+            }
+        };
+    }
+
+    public static TProtocolPair fromSingleProtocol(final TProtocol protocol) {
+        return new TProtocolPair() {
+            @Override
+            public TProtocol getInputProtocol() {
+                return protocol;
+            }
+
+            @Override
+            public TProtocol getOutputProtocol() {
+                return protocol;
+            }
+        };
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/duplex/TTransportPair.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/duplex/TTransportPair.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.duplex;
+
+import org.apache.thrift.transport.TTransport;
+
+/***
+ * An interface for representing a pair of protocols: one for input and one for output.
+ */
+public abstract class TTransportPair {
+    public abstract TTransport getInputTransport();
+    public abstract TTransport getOutputTransport();
+
+    public static TTransportPair fromSeparateTransports(final TTransport inputTransport,
+                                                        final TTransport outputTransport) {
+        return new TTransportPair() {
+            @Override
+            public TTransport getInputTransport() {
+                return inputTransport;
+            }
+
+            @Override
+            public TTransport getOutputTransport() {
+                return outputTransport;
+            }
+        };
+    }
+
+    public static TTransportPair fromSingleTransport(final TTransport transport) {
+        return new TTransportPair() {
+            @Override
+            public TTransport getInputTransport() {
+                return transport;
+            }
+
+            @Override
+            public TTransport getOutputTransport() {
+                return transport;
+            }
+        };
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessor.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.processor;
+
+import com.facebook.nifty.core.RequestContext;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocol;
+
+public interface NiftyProcessor
+{
+    public boolean process(TProtocol in, TProtocol out, RequestContext requestContext)
+            throws TException;
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessorAdapters.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessorAdapters.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.processor;
+
+import com.facebook.nifty.core.RequestContext;
+import org.apache.thrift.TException;
+import org.apache.thrift.TProcessor;
+import org.apache.thrift.TProcessorFactory;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TTransport;
+
+public class NiftyProcessorAdapters
+{
+    public static NiftyProcessor processorFromTProcessor(final TProcessor standardThriftProcessor)
+    {
+        checkProcessMethodSignature();
+
+        return new NiftyProcessor()
+        {
+            @Override
+            public boolean process(TProtocol in, TProtocol out, RequestContext requestContext) throws TException
+            {
+                return standardThriftProcessor.process(in, out);
+            }
+        };
+    }
+
+    public static NiftyProcessorFactory factoryFromTProcessor(final TProcessor standardThriftProcessor)
+    {
+        checkProcessMethodSignature();
+
+        return new NiftyProcessorFactory()
+        {
+            @Override
+            public NiftyProcessor getProcessor(TTransport transport)
+            {
+                return processorFromTProcessor(standardThriftProcessor);
+            }
+        };
+    }
+
+    public static NiftyProcessorFactory factoryFromTProcessorFactory(final TProcessorFactory standardThriftProcessorFactory)
+    {
+        checkProcessMethodSignature();
+
+        return new NiftyProcessorFactory()
+        {
+            @Override
+            public NiftyProcessor getProcessor(TTransport transport)
+            {
+                return processorFromTProcessor(standardThriftProcessorFactory.getProcessor(transport));
+            }
+        };
+    }
+
+    /**
+     * Catch the mismatch early if someone tries to pass our internal variant of TProcessor with
+     * a different signature on the process() method into these adapters.
+     */
+    private static void checkProcessMethodSignature()
+    {
+        try {
+            TProcessor.class.getMethod("process", TProtocol.class, TProtocol.class);
+        }
+        catch (NoSuchMethodException e) {
+            // Facebook's TProcessor variant needs processor adapters from a different package
+            throw new IllegalStateException("The loaded TProcessor class is not supported by version of the adapters");
+        }
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessorFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.processor;
+
+import org.apache.thrift.transport.TTransport;
+
+public interface NiftyProcessorFactory
+{
+    public NiftyProcessor getProcessor(TTransport transport);
+}

--- a/nifty-core/src/test/java/com/facebook/nifty/core/TestServerDefBuilder.java
+++ b/nifty-core/src/test/java/com/facebook/nifty/core/TestServerDefBuilder.java
@@ -15,7 +15,7 @@
  */
 package com.facebook.nifty.core;
 
-import org.apache.thrift.TProcessor;
+import com.facebook.nifty.processor.NiftyProcessor;
 import org.easymock.EasyMock;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -39,7 +39,7 @@ public class TestServerDefBuilder
     {
         try {
             new ThriftServerDefBuilder()
-                    .withProcessor(EasyMock.createMock(TProcessor.class))
+                    .withProcessor(EasyMock.createMock(NiftyProcessor.class))
                     .build();
         }
         catch (Exception e) {


### PR DESCRIPTION
This is a different take on cleaning up the relationship between nifty and nifty-fbcode.

1) makes the frame codec a configurable part of the server via ThriftServerDef
2) changes the server def to use duplex protocol factories, so that protocols which require that inputprotocol==outputprotocol (e.g. header protocol) can provide a factory to enforce this instead of having the nifty-fbcode version of dispatcher special-case this
3) uses NiftyProcessor instead of thrift's TProcessor, and uses adapters to adapt the standard thrift TProcess to a NiftyProcessor (and nifty-fbcode will adapt a fbcode thrift TProcessor to a NiftyProcessor with a few differences)... 

The NiftyProcessor and adapter classes also opens things up to adding more functionality to NiftyProcessor that swift can take advantage of while still working with a version of nifty that supports standard thrift (e.g. a processor that returns a future, with an adapter for standard thrift processors that just gets the result synchronously and returns an immediate future).

With this diff I'll be able to delete the duplicate versions of NettyServerTransport, NiftyBootstrap and NiftyDispatcher in nifty-fbcode, and use the same version of each of these as standard nifty does.
