### PR TITLE
Modifications to support sending out-of-order responses in some scenarios

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
@@ -42,6 +42,11 @@ public class TNiftyTransport extends TTransport
         this.out = ChannelBuffers.dynamicBuffer(DEFAULT_OUTPUT_BUFFER_SIZE);
     }
 
+    public TNiftyTransport(Channel channel, ThriftMessage message)
+    {
+        this(channel, message.getBuffer(), message.getTransportType());
+    }
+
     @Override
     public boolean isOpen()
     {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftMessage.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftMessage.java
@@ -37,4 +37,42 @@ public class ThriftMessage
     {
         return transportType;
     }
+
+    /**
+     * Gets a {@link Factory} for creating messages similar to this one. Used by {@link
+     * NiftyDispatcher} to create response messages that are similar to their corresponding
+     * request messages.
+     *
+     * @return The {@link Factory}
+     */
+    public Factory getMessageFactory()
+    {
+        return new Factory()
+        {
+            @Override
+            public ThriftMessage create(ChannelBuffer messageBuffer)
+            {
+                return new ThriftMessage(messageBuffer, getTransportType());
+            }
+        };
+    }
+
+    /**
+     * Standard Thrift clients require ordered responses, so even though Nifty can run multiple
+     * requests from the same client at the same time, the responses have to be held until all
+     * previous responses are ready and have been written. However, through the use of extended
+     * protocols and codecs, a request can indicate that the client understands
+     * out-of-order responses.
+     *
+     * @return {@code true} if ordered responses are required
+     */
+    public boolean isOrderedResponsesRequired()
+    {
+        return true;
+    }
+
+    public static interface Factory
+    {
+        public ThriftMessage create(ChannelBuffer messageBuffer);
+    }
 }


### PR DESCRIPTION
This adds the necessary hooks into nifty so that extended codecs + protocols can create messages for which out-of-order responses are allowed
