### PR TITLE
Skip writes to disconnected clients

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
@@ -118,8 +118,11 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
                         RequestContext.clearCurrentContext();
                     }
 
-                    ThriftMessage response = message.getMessageFactory().create(messageTransport.getOutputBuffer());
-                    writeResponse(ctx, response, requestSequenceId, message.isOrderedResponsesRequired());
+                    // Only write response if the client is still there
+                    if (ctx.getChannel().isConnected()) {
+                        ThriftMessage response = message.getMessageFactory().create(messageTransport.getOutputBuffer());
+                        writeResponse(ctx, response, requestSequenceId, message.isOrderedResponsesRequired());
+                    }
                 }
                 catch (TException e) {
                     Channels.fireExceptionCaught(ctx, e);

--- a/nifty-load-tester/src/main/resources/logback.xml
+++ b/nifty-load-tester/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{15} - %msg%n%throwable{10}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
Found when running load tester, having a bunch of clients from a load generator sending requests, and then killing the load generator... there were a TON of ClosedChannelExceptions.

To cut down on this, we can skip trying to send a reply if we already know the remote end was disconnected.
