### PR TITLE
Add consistency checks to out-of-order support

### DIFF
--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
@@ -27,6 +27,8 @@ import com.google.inject.Stage;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TTransportException;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -50,6 +52,7 @@ public class TestNiftyClient
     @BeforeMethod(alwaysRun = true)
     public void setup() throws IOException
     {
+        InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
         ServerSocket s = new ServerSocket();
         s.bind(new InetSocketAddress(0));
         port = s.getLocalPort();

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -21,6 +21,8 @@ import com.facebook.nifty.client.NiftyClient;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -43,19 +45,20 @@ public class TestNiftyClientTimeout
 
     @BeforeTest(alwaysRun = true)
     public void init() {
-      // must load DelegateSelectorProvider before entire test suite to
-      // properly wire up selector provider.
-      DelegateSelectorProvider.init();
+        // must load DelegateSelectorProvider before entire test suite to
+        // properly wire up selector provider.
+        DelegateSelectorProvider.init();
     }
 
     @BeforeMethod(alwaysRun = true)
     public void setup() {
-      DelegateSelectorProvider.makeDeaf();
+        InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
+        DelegateSelectorProvider.makeDeaf();
     }
 
     @AfterMethod(alwaysRun = true)
     public void tearDown() {
-      DelegateSelectorProvider.makeUndeaf();
+        DelegateSelectorProvider.makeUndeaf();
     }
 
     @Test(timeOut = 2000)

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainClient.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainClient.java
@@ -27,9 +27,12 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
@@ -43,6 +46,12 @@ public class TestPlainClient {
     private NiftyBootstrap bootstrap;
     private static Logger log = LoggerFactory.getLogger(TestPlainClient.class);
     int port;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup()
+    {
+        InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
+    }
 
     @Test
     public void testPlainUnframedClient() throws TException {

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
@@ -31,6 +31,8 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -57,6 +59,7 @@ public class TestPlainServer
     public void setup()
     {
         bootstrap = null;
+        InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
Partial ordering is not supported: all requests on a channel should either support out-of-order or not support it. This adds consistency checks that every header on every message a client sends should indicate out-of-order is supported, or the client should never indicate it supports out-of-order.
