### PR TITLE
Catch more exceptions in async client code

### DIFF
--- a/nifty-client/pom.xml
+++ b/nifty-client/pom.xml
@@ -83,5 +83,9 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Some experimenting with the load generator and also a bug report from Martin indicated that there were cases where exceptions were getting thrown in async client handlers that were not caught, and could prevent us from ever firing either the success or failure callbacks for a client call. This diff tries to catch all of those cases, to guarantee we'll fire one of the callbacks.
