### PR TITLE
Support processors that return futures

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessor.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/processor/NiftyProcessor.java
@@ -16,11 +16,11 @@
 package com.facebook.nifty.processor;
 
 import com.facebook.nifty.core.RequestContext;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
 
 public interface NiftyProcessor
 {
-    public boolean process(TProtocol in, TProtocol out, RequestContext requestContext)
-            throws TException;
+    public ListenableFuture<Boolean> process(TProtocol in, TProtocol out, RequestContext requestContext) throws TException;
 }


### PR DESCRIPTION
This allows a server that handles requests by starting async work to handle more in-flight requests than the number of threads in the worker pool
