### PR TITLE
Set nifty thread names all the time correctly.

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
@@ -16,17 +16,21 @@
 package com.facebook.nifty.client;
 
 import com.facebook.nifty.core.NettyConfigBuilderBase;
+import com.facebook.nifty.core.NiftyTimer;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
+
 import org.jboss.netty.channel.socket.nio.NioSocketChannelConfig;
 import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.Timer;
 
 import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
@@ -88,17 +92,12 @@ public class NettyClientConfigBuilder extends NettyConfigBuilderBase<NettyClient
         return new NettyClientConfig(
                 getBootstrapOptions(),
                 defaultSocksProxyAddress,
-                timer != null ? timer : buildDefaultTimer(),
+                timer != null ? timer : new NiftyTimer(threadNamePattern("")),
                 bossExecutor != null ? bossExecutor : buildDefaultBossExecutor(),
                 bossThreadCount,
                 workerExecutor != null ? workerExecutor : buildDefaultWorkerExecutor(),
                 workerThreadCount
         );
-    }
-
-    private Timer buildDefaultTimer()
-    {
-        return new HashedWheelTimer(renamingDaemonThreadFactory(threadNamePattern("-timer-%s")));
     }
 
     private ExecutorService buildDefaultBossExecutor()

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerConfigBuilder.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerConfigBuilder.java
@@ -18,9 +18,9 @@ package com.facebook.nifty.core;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
+
 import org.jboss.netty.channel.socket.ServerSocketChannelConfig;
 import org.jboss.netty.channel.socket.nio.NioSocketChannelConfig;
-import org.jboss.netty.util.HashedWheelTimer;
 import org.jboss.netty.util.Timer;
 
 import java.lang.reflect.Proxy;
@@ -87,17 +87,12 @@ public class NettyServerConfigBuilder extends NettyConfigBuilderBase<NettyServer
 
         return new NettyServerConfig(
                 getBootstrapOptions(),
-                timer != null ? timer : buildDefaultTimer(),
+                timer != null ? timer : new NiftyTimer(threadNamePattern("")),
                 bossExecutor != null ? bossExecutor : buildDefaultBossExecutor(),
                 bossThreadCount,
                 workerExecutor != null ? workerExecutor : buildDefaultWorkerExecutor(),
                 workerThreadCount
         );
-    }
-
-    private Timer buildDefaultTimer()
-    {
-        return new HashedWheelTimer(renamingDaemonThreadFactory(threadNamePattern("-timer-%s")));
     }
 
     private ExecutorService buildDefaultBossExecutor()
@@ -119,10 +114,5 @@ public class NettyServerConfigBuilder extends NettyConfigBuilderBase<NettyServer
     private ThreadFactory renamingThreadFactory(String nameFormat)
     {
         return new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
-    }
-
-    private ThreadFactory renamingDaemonThreadFactory(String nameFormat)
-    {
-        return new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build();
     }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -15,8 +15,6 @@
  */
 package com.facebook.nifty.core;
 
-import com.google.common.primitives.Ints;
-
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
@@ -31,11 +29,14 @@ import org.jboss.netty.channel.ServerChannelFactory;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
+import org.jboss.netty.channel.socket.nio.NioServerBossPool;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioWorkerPool;
 import org.jboss.netty.handler.timeout.IdleStateHandler;
 import org.jboss.netty.logging.InternalLoggerFactory;
 import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.jboss.netty.util.ExternalResourceReleasable;
+import org.jboss.netty.util.ThreadNameDeterminer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,10 +124,8 @@ public class NettyServerTransport implements ExternalResourceReleasable
         ioWorkerExecutor = nettyServerConfig.getWorkerExecutor();
         int ioWorkerThreadCount = nettyServerConfig.getWorkerThreadCount();
 
-        channelFactory = new NioServerSocketChannelFactory(bossExecutor,
-                                                           bossThreadCount,
-                                                           ioWorkerExecutor,
-                                                           ioWorkerThreadCount);
+        channelFactory = new NioServerSocketChannelFactory(new NioServerBossPool(bossExecutor, bossThreadCount, ThreadNameDeterminer.CURRENT),
+                                                           new NioWorkerPool(ioWorkerExecutor, ioWorkerThreadCount, ThreadNameDeterminer.CURRENT));
         start(channelFactory);
     }
 

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyTimer.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyTimer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.ThreadNameDeterminer;
+
+import javax.annotation.PreDestroy;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+public final class NiftyTimer
+    extends HashedWheelTimer
+    implements Closeable
+{
+    public NiftyTimer(String prefix, long tickDuration, TimeUnit unit, int ticksPerWheel)
+    {
+        super(new ThreadFactoryBuilder().setNameFormat(prefix + "-timer-%s").setDaemon(true).build(),
+              ThreadNameDeterminer.CURRENT,
+              tickDuration,
+              unit,
+              ticksPerWheel);
+    }
+
+    public NiftyTimer(String prefix)
+    {
+        this(prefix, 100, TimeUnit.MILLISECONDS, 512);
+    }
+
+    @PreDestroy
+    @Override
+    public void close()
+    {
+        stop();
+    }
+}

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -124,7 +124,7 @@ public class TestNiftyClientTimeout
     private boolean isTimeoutException(Throwable throwable) {
         Throwable rootCause = Throwables.getRootCause(throwable);
         // Look for a java.net.ConnectException, with the message "connection timed out"
-        return (rootCause instanceof ConnectException &&
-                rootCause.getMessage().compareTo("connection timed out") == 0);
+        return rootCause instanceof ConnectException &&
+                rootCause.getMessage().startsWith("connection timed out");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.6.2.Final</version>
+                <version>3.7.0.Final</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This requires a newer version of Netty as the timer renaming code appeared post-3.6.2.
