### PR TITLE
Add pluggable security (authentication and encryption)

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -99,8 +99,10 @@ public class NettyServerTransport implements ExternalResourceReleasable
             {
                 ChannelPipeline cp = Channels.pipeline();
                 TProtocolFactory inputProtocolFactory = def.getDuplexProtocolFactory().getInputProtocolFactory();
+                NiftySecurityHandlers securityHandlers = def.getSecurityFactory().getSecurityHandlers(def);
                 cp.addLast("connectionLimiter", connectionLimiter);
                 cp.addLast(ChannelStatistics.NAME, channelStatistics);
+                cp.addLast("encryptionHandler", securityHandlers.getEncryptionHandler());
                 cp.addLast("frameCodec", def.getThriftFrameCodecFactory().create(def.getMaxFrameSize(),
                                                                                  inputProtocolFactory));
                 if (def.getClientIdleTimeout() != null) {
@@ -113,6 +115,7 @@ public class NettyServerTransport implements ExternalResourceReleasable
                     cp.addLast("idleDisconnectHandler", new IdleDisconnectHandler());
                 }
 
+                cp.addLast("authHandler", securityHandlers.getAuthenticationHandler());
                 cp.addLast("dispatcher", new NiftyDispatcher(def));
                 cp.addLast("exceptionLogger", new NiftyExceptionLogger());
                 return cp;

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyNoOpSecurityFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyNoOpSecurityFactory.java
@@ -20,6 +20,8 @@ import org.jboss.netty.channel.SimpleChannelHandler;
 
 public class NiftyNoOpSecurityFactory implements NiftySecurityFactory
 {
+    final ChannelHandler noOpHandler = new SimpleChannelHandler();
+
     @Override
     public NiftySecurityHandlers getSecurityHandlers(ThriftServerDef def)
     {
@@ -28,13 +30,13 @@ public class NiftyNoOpSecurityFactory implements NiftySecurityFactory
             @Override
             public ChannelHandler getAuthenticationHandler()
             {
-                return new SimpleChannelHandler();
+                return noOpHandler;
             }
 
             @Override
             public ChannelHandler getEncryptionHandler()
             {
-                return new SimpleChannelHandler();
+                return noOpHandler;
             }
         };
     }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyNoOpSecurityFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyNoOpSecurityFactory.java
@@ -16,11 +16,20 @@
 package com.facebook.nifty.core;
 
 import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.channel.SimpleChannelHandler;
 
 public class NiftyNoOpSecurityFactory implements NiftySecurityFactory
 {
-    final ChannelHandler noOpHandler = new SimpleChannelHandler();
+    static final ChannelHandler noOpHandler = new SimpleChannelHandler() {
+        @Override
+        public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception
+        {
+            super.channelOpen(ctx, e);
+            ctx.getPipeline().remove(this);
+        }
+    };
 
     @Override
     public NiftySecurityHandlers getSecurityHandlers(ThriftServerDef def)

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyNoOpSecurityFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyNoOpSecurityFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.SimpleChannelHandler;
+
+public class NiftyNoOpSecurityFactory implements NiftySecurityFactory
+{
+    @Override
+    public NiftySecurityHandlers getSecurityHandlers(ThriftServerDef def)
+    {
+        return new NiftySecurityHandlers()
+        {
+            @Override
+            public ChannelHandler getAuthenticationHandler()
+            {
+                return new SimpleChannelHandler();
+            }
+
+            @Override
+            public ChannelHandler getEncryptionHandler()
+            {
+                return new SimpleChannelHandler();
+            }
+        };
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftySecurityFactory.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftySecurityFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+public interface NiftySecurityFactory
+{
+    NiftySecurityHandlers getSecurityHandlers(ThriftServerDef def);
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftySecurityHandlers.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftySecurityHandlers.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import org.jboss.netty.channel.ChannelHandler;
+
+public interface NiftySecurityHandlers
+{
+    ChannelHandler getAuthenticationHandler();
+    ChannelHandler getEncryptionHandler();
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -39,6 +39,7 @@ public class ThriftServerDef
     private final ThriftFrameCodecFactory thriftFrameCodecFactory;
     private final Executor executor;
     private final String name;
+    private final NiftySecurityFactory securityFactory;
 
     public ThriftServerDef(
             String name,
@@ -50,7 +51,8 @@ public class ThriftServerDef
             TDuplexProtocolFactory duplexProtocolFactory,
             Duration clientIdleTimeout,
             ThriftFrameCodecFactory thriftFrameCodecFactory,
-            Executor executor)
+            Executor executor,
+            NiftySecurityFactory securityFactory)
     {
         this.name = name;
         this.serverPort = serverPort;
@@ -62,6 +64,7 @@ public class ThriftServerDef
         this.clientIdleTimeout = clientIdleTimeout;
         this.thriftFrameCodecFactory = thriftFrameCodecFactory;
         this.executor = executor;
+        this.securityFactory = securityFactory;
     }
 
     public static ThriftServerDefBuilder newBuilder()
@@ -116,5 +119,10 @@ public class ThriftServerDef
     public ThriftFrameCodecFactory getThriftFrameCodecFactory()
     {
         return thriftFrameCodecFactory;
+    }
+
+    public NiftySecurityFactory getSecurityFactory()
+    {
+        return securityFactory;
     }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilderBase.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilderBase.java
@@ -62,6 +62,7 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
     private Executor executor;
     private String name = "nifty-" + ID.getAndIncrement();
     private Duration clientIdleTimeout;
+    private NiftySecurityFactory securityFactory;
 
     /**
      * The default maximum allowable size for a single incoming thrift request or outgoing thrift
@@ -92,6 +93,7 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
         };
         this.clientIdleTimeout = null;
         this.thriftFrameCodecFactory = new DefaultThriftFrameCodecFactory();
+        this.securityFactory = new NiftyNoOpSecurityFactory();
     }
 
     /**
@@ -221,6 +223,12 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
         return (T) this;
     }
 
+    public T withSecurityFactory(NiftySecurityFactory securityFactory)
+    {
+        this.securityFactory = securityFactory;
+        return (T) this;
+    }
+
     /**
      * Build the ThriftServerDef
      */
@@ -247,6 +255,7 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
                 duplexProtocolFactory,
                 clientIdleTimeout,
                 thriftFrameCodecFactory,
-                executor);
+                executor,
+                securityFactory);
     }
 }


### PR DESCRIPTION
Also add a no-op security factory which is also the default. Other
factories (user-written) can be plugged in to use SSL, SASL, Kerberos,
or other types of authentication and encryption.
