### PR TITLE
Split read based timeouts.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+Changes
+=======
+
+* 0.11.0
+
+- Introduce receiveTimeout on NiftyClient and NiftyClientChannel
+- Changed the behaviour of readTimeout to measure the time that a
+  server can not send a response at all.
+
+- Started CHANGES and NEWS files.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,28 @@
+News
+====
+
+* 0.11.0
+
+The nifty client code has only one timeout when reading: readTimeout.
+
+It controls the amount of time that a client is willing for the server
+to complete a response.
+
+This release introduces a second timeout, receiveTimeout and changes
+the semantics of readTimeout:
+
+- receiveTimeout now reflects the amount of time that a client is
+  willing to wait for the server complete a response.
+
+- readTimeout is the amount of a time that can pass without the server
+  sending any data.
+
+In the most general sense, readTimeout is the maximum time to first
+byte and receiveTimeout is the maximum time to last byte for a
+response. However, readTimeout also controls the amount of time that a
+server can fall silent during sending out a response before the client
+times out.
+
+As long as a server makes progress and keeps sending out data
+continuously, the readTimeout will not fire. The receiveTimout will
+fire even if while the server sends data.

--- a/nifty-client/src/main/java/com/facebook/nifty/client/FramedClientConnector.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/FramedClientConnector.java
@@ -17,6 +17,7 @@ package com.facebook.nifty.client;
 
 import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.google.common.net.HostAndPort;
+
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
@@ -68,7 +69,9 @@ public class FramedClientConnector extends AbstractClientConnector<FramedClientC
     public FramedClientChannel newThriftClientChannel(Channel nettyChannel, Timer timer)
     {
         FramedClientChannel channel = new FramedClientChannel(nettyChannel, timer, getProtocolFactory());
-        channel.getNettyChannel().getPipeline().addLast("thriftHandler", channel);
+        ChannelPipeline cp = nettyChannel.getPipeline();
+        TimeoutHandler.addToPipeline(cp);
+        cp.addLast("thriftHandler", channel);
         return channel;
     }
 
@@ -80,6 +83,7 @@ public class FramedClientConnector extends AbstractClientConnector<FramedClientC
             public ChannelPipeline getPipeline()
                     throws Exception {
                 ChannelPipeline cp = Channels.pipeline();
+                TimeoutHandler.addToPipeline(cp);
                 cp.addLast("frameEncoder", new LengthFieldPrepender(LENGTH_FIELD_LENGTH));
                 cp.addLast(
                         "frameDecoder",

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientChannel.java
@@ -21,6 +21,8 @@ import org.apache.thrift.TException;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 
+import javax.annotation.Nullable;
+
 public interface NiftyClientChannel {
     /**
      * Sends a single message asynchronously, and notifies the {@link Listener}
@@ -42,7 +44,7 @@ public interface NiftyClientChannel {
      *
      * @param sendTimeout
      */
-    void setSendTimeout(Duration sendTimeout);
+    void setSendTimeout(@Nullable Duration sendTimeout);
 
     /**
      * Returns the timeout most recently set by
@@ -58,7 +60,7 @@ public interface NiftyClientChannel {
      *
      * @param receiveTimeout
      */
-    void setReceiveTimeout(Duration receiveTimeout);
+    void setReceiveTimeout(@Nullable Duration receiveTimeout);
 
     /**
      * Returns the timeout most recently set by
@@ -67,6 +69,21 @@ public interface NiftyClientChannel {
      * @return
      */
     Duration getReceiveTimeout();
+
+    /**
+     * Sets a timeout used to limit the time that the client waits for data to be sent by the server.
+     *
+     * @param readTimeout
+     */
+    void setReadTimeout(@Nullable Duration readTimeout);
+
+    /**
+     * Returns the timeout most recently set by
+     * {@link NiftyClientChannel#setReadTimeout(io.airlift.units.Duration)}
+     *
+     * @return
+     */
+    Duration getReadTimeout();
 
     /**
      * Closes the channel

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TimeoutHandler.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TimeoutHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.client;
+
+import org.jboss.netty.channel.ChannelDownstreamHandler;
+import org.jboss.netty.channel.ChannelEvent;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelUpstreamHandler;
+import org.jboss.netty.channel.MessageEvent;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class TimeoutHandler implements ChannelUpstreamHandler, ChannelDownstreamHandler
+{
+    private static final String NAME = "_TIMEOUT_HANDLER";
+
+    private volatile long lastMessageReceivedNanos = 0L;
+    private volatile long  lastMessageSentNanos = 0L;
+
+    public static synchronized void addToPipeline(ChannelPipeline cp)
+    {
+        checkNotNull(cp, "cp is null");
+        if (cp.get(NAME) == null) {
+            cp.addFirst(NAME, new TimeoutHandler());
+        }
+    }
+
+    public static TimeoutHandler findTimeoutHandler(ChannelPipeline cp)
+    {
+        return (TimeoutHandler) cp.get(NAME);
+    }
+
+    private TimeoutHandler()
+    {
+    }
+
+    @Override
+    public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e)
+        throws Exception
+    {
+        if (e instanceof MessageEvent) {
+            lastMessageReceivedNanos = System.nanoTime();
+        }
+        ctx.sendUpstream(e);
+    }
+
+    @Override
+    public void handleDownstream(ChannelHandlerContext ctx, ChannelEvent e)
+        throws Exception
+    {
+        if (e instanceof MessageEvent) {
+            lastMessageSentNanos = System.nanoTime();
+        }
+        ctx.sendDownstream(e);
+    }
+
+    public long getLastMessageReceivedNanos()
+    {
+        return lastMessageReceivedNanos;
+    }
+
+    public long getLastMessageSentNanos()
+    {
+        return lastMessageSentNanos;
+    }
+}

--- a/nifty-client/src/main/java/com/facebook/nifty/client/UnframedClientConnector.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/UnframedClientConnector.java
@@ -51,7 +51,9 @@ public class UnframedClientConnector extends AbstractClientConnector<UnframedCli
     public UnframedClientChannel newThriftClientChannel(Channel nettyChannel, Timer timer)
     {
         UnframedClientChannel channel = new UnframedClientChannel(nettyChannel, timer, getProtocolFactory());
-        channel.getNettyChannel().getPipeline().addLast("thriftHandler", channel);
+        ChannelPipeline cp = nettyChannel.getPipeline();
+        TimeoutHandler.addToPipeline(cp);
+        cp.addLast("thriftHandler", channel);
         return channel;
     }
 
@@ -63,6 +65,7 @@ public class UnframedClientConnector extends AbstractClientConnector<UnframedCli
             public ChannelPipeline getPipeline()
                     throws Exception {
                 ChannelPipeline cp = Channels.pipeline();
+                TimeoutHandler.addToPipeline(cp);
                 cp.addLast("thriftUnframedDecoder", new ThriftUnframedDecoder());
                 return cp;
             }

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -39,8 +39,9 @@ import static org.testng.Assert.fail;
 public class TestNiftyClientTimeout
 {
     private static final Duration TEST_CONNECT_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final Duration TEST_RECEIVE_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
     private static final Duration TEST_READ_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
-    private static final Duration TEST_WRITE_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
+    private static final Duration TEST_SEND_TIMEOUT = new Duration(500, TimeUnit.MILLISECONDS);
     private static final int TEST_MAX_FRAME_SIZE = 16777216;
 
     @BeforeTest(alwaysRun = true)
@@ -71,7 +72,7 @@ public class TestNiftyClientTimeout
                 client.connectSync(new InetSocketAddress(port),
                                    TEST_CONNECT_TIMEOUT,
                                    TEST_READ_TIMEOUT,
-                                   TEST_WRITE_TIMEOUT,
+                                   TEST_SEND_TIMEOUT,
                                    TEST_MAX_FRAME_SIZE);
         }
         catch (Throwable throwable) {
@@ -100,8 +101,9 @@ public class TestNiftyClientTimeout
             ListenableFuture<FramedClientChannel> future =
                             client.connectAsync(new FramedClientConnector(new InetSocketAddress(port)),
                                                 TEST_CONNECT_TIMEOUT,
+                                                TEST_RECEIVE_TIMEOUT,
                                                 TEST_READ_TIMEOUT,
-                                                TEST_WRITE_TIMEOUT,
+                                                TEST_SEND_TIMEOUT,
                                                 TEST_MAX_FRAME_SIZE);
             // Wait while NiftyClient attempts to connect the channel
             future.get();


### PR DESCRIPTION
A Nifty client actually has to deal with two separate timeouts:
- request timeout - the maximum amount of time that the caller is willing to wait
  for an I/O request to complete
- receive timeout - the maximum amount of time that the client is willing for the
  server to make any progress

These times can be very different. e.g. a server might trickle a request sending a
packet every three seconds for a long time and the caller is willing to wait minutes
for a request to complete as long as it makes progress.

This patch fixes the name confusion around read, request and receive timeouts in the
nifty client code, uses consistent naming everywhere and adds a new timeout (requestTimeout)
while the existing receiveTimeout now does what the name suggests.

Existing code should still work fine as both timeouts are set to the same value by default.
