### PR TITLE
Add ConnectionContext

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/ConnectionContext.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ConnectionContext.java
@@ -15,13 +15,22 @@
  */
 package com.facebook.nifty.core;
 
-import org.apache.thrift.protocol.TProtocol;
+import java.net.SocketAddress;
+import java.util.Map;
 
-public interface RequestContext
+public interface ConnectionContext
 {
-    TProtocol getOutputProtocol();
+    /**
+     * Gets the remote address of the client that made the request
+     *
+     * @return The client's remote address as a {@link SocketAddress}
+     */
+    public SocketAddress getRemoteAddress();
 
-    TProtocol getInputProtocol();
-
-    ConnectionContext getConnectionContext();
+    /**
+     * Gets a map of additional attributes specific to the connection
+     *
+     * @return Map of additional attributes
+     */
+    public Map<String, Object> getAttributes();
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ConnectionContextHandler.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ConnectionContextHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+
+public class ConnectionContextHandler extends SimpleChannelUpstreamHandler
+{
+    @Override
+    public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception
+    {
+        super.channelConnected(ctx, e);
+
+        ConnectionContext connectionContext = ConnectionContexts.getContext(ctx.getChannel());
+        if (connectionContext instanceof NiftyConnectionContext) {
+            NiftyConnectionContext niftyConnectionContext = (NiftyConnectionContext)connectionContext;
+            niftyConnectionContext.setRemoteAddress(ctx.getChannel().getRemoteAddress());
+        }
+    }
+}

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ConnectionContexts.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ConnectionContexts.java
@@ -15,13 +15,20 @@
  */
 package com.facebook.nifty.core;
 
-import org.apache.thrift.protocol.TProtocol;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelLocal;
 
-public interface RequestContext
+public class ConnectionContexts
 {
-    TProtocol getOutputProtocol();
+    private static final ChannelLocal<ConnectionContext> context = new ChannelLocal<ConnectionContext>(true) {
+        @Override
+        protected ConnectionContext initialValue(Channel channel)
+        {
+            return new NiftyConnectionContext();
+        }
+    };
 
-    TProtocol getInputProtocol();
-
-    ConnectionContext getConnectionContext();
+    public static ConnectionContext getContext(Channel channel) {
+        return context.get(channel);
+    }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -100,6 +100,7 @@ public class NettyServerTransport implements ExternalResourceReleasable
                 ChannelPipeline cp = Channels.pipeline();
                 TProtocolFactory inputProtocolFactory = def.getDuplexProtocolFactory().getInputProtocolFactory();
                 NiftySecurityHandlers securityHandlers = def.getSecurityFactory().getSecurityHandlers(def);
+                cp.addLast("connectionContext", new ConnectionContextHandler());
                 cp.addLast("connectionLimiter", connectionLimiter);
                 cp.addLast(ChannelStatistics.NAME, channelStatistics);
                 cp.addLast("encryptionHandler", securityHandlers.getEncryptionHandler());

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyConnectionContext.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyConnectionContext.java
@@ -15,13 +15,29 @@
  */
 package com.facebook.nifty.core;
 
-import org.apache.thrift.protocol.TProtocol;
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-public interface RequestContext
+public class NiftyConnectionContext implements ConnectionContext
 {
-    TProtocol getOutputProtocol();
+    private SocketAddress remoteAddress;
+    private Map<String, Object> attributes = new ConcurrentHashMap<>();
 
-    TProtocol getInputProtocol();
+    @Override
+    public SocketAddress getRemoteAddress()
+    {
+        return remoteAddress;
+    }
 
-    ConnectionContext getConnectionContext();
+    public void setRemoteAddress(SocketAddress remoteAddress)
+    {
+        this.remoteAddress = remoteAddress;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes()
+    {
+        return attributes;
+    }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyDispatcher.java
@@ -132,7 +132,8 @@ public class NiftyDispatcher extends SimpleChannelUpstreamHandler
 
                 try {
                     try {
-                        RequestContext requestContext = new NiftyRequestContext(ctx.getChannel(), inProtocol, outProtocol, messageTransport);
+                        ConnectionContext connectionContext = ConnectionContexts.getContext(ctx.getChannel());
+                        RequestContext requestContext = new NiftyRequestContext(connectionContext, inProtocol, outProtocol, messageTransport);
                         RequestContexts.setCurrentContext(requestContext);
                         processFuture = processorFactory.getProcessor(messageTransport).process(inProtocol, outProtocol, requestContext);
                     }

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyRequestContext.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyRequestContext.java
@@ -16,15 +16,12 @@
 package com.facebook.nifty.core;
 
 import org.apache.thrift.protocol.TProtocol;
-import org.jboss.netty.channel.Channel;
 
 import java.net.SocketAddress;
 
-import static com.google.common.base.Preconditions.checkState;
-
 public class NiftyRequestContext implements RequestContext
 {
-    private final SocketAddress remoteAddress;
+    private final ConnectionContext connectionContext;
     private final TProtocol inputProtocol;
     private final TProtocol outputProtocol;
     private final TNiftyTransport niftyTransport;
@@ -34,12 +31,6 @@ public class NiftyRequestContext implements RequestContext
      *
      * @return The client's remote address as a {@link SocketAddress}
      */
-    @Override
-    public SocketAddress getRemoteAddress()
-    {
-        return remoteAddress;
-    }
-
     @Override
     public TProtocol getInputProtocol()
     {
@@ -57,11 +48,17 @@ public class NiftyRequestContext implements RequestContext
         return niftyTransport;
     }
 
-    NiftyRequestContext(Channel channel, TProtocol inputProtocol, TProtocol outputProtocol, TNiftyTransport niftyTransport)
+    @Override
+    public ConnectionContext getConnectionContext()
     {
+        return connectionContext;
+    }
+
+    NiftyRequestContext(ConnectionContext connectionContext, TProtocol inputProtocol, TProtocol outputProtocol, TNiftyTransport niftyTransport)
+    {
+        this.connectionContext = connectionContext;
         this.niftyTransport = niftyTransport;
         this.inputProtocol = inputProtocol;
         this.outputProtocol = outputProtocol;
-        this.remoteAddress = channel.getRemoteAddress();
     }
 }

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyServer.java
@@ -85,7 +85,7 @@ public class TestNiftyServer
 
                         for (LogEntry message : messages) {
                             log.info("[Client: {}] {}: {}",
-                                    context.getRemoteAddress(),
+                                    context.getConnectionContext().getRemoteAddress(),
                                     message.getCategory(),
                                     message.getMessage());
                         }

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
@@ -17,7 +17,6 @@ package com.facebook.nifty.server;
 
 import com.facebook.nifty.client.NiftyClient;
 import com.facebook.nifty.core.NiftyBootstrap;
-import com.facebook.nifty.core.NiftyRequestContext;
 import com.facebook.nifty.core.RequestContext;
 import com.facebook.nifty.core.RequestContexts;
 import com.facebook.nifty.core.ThriftServerDefBuilder;
@@ -171,7 +170,7 @@ public class TestPlainServer
 
                         for (LogEntry message : messages) {
                             log.info("[Client: {}] {}: {}",
-                                     context.getRemoteAddress(),
+                                     context.getConnectionContext().getRemoteAddress(),
                                      message.getCategory(),
                                      message.getMessage());
                         }


### PR DESCRIPTION
Used to track per-connection data, as opposed to RequestContext which is
per request.
Also move getRemoteAddress() from RequestContext to ConnectionContext (API breaking change).
