### PR TITLE
Niftyclientchanneltransport

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfig.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfig.java
@@ -18,7 +18,6 @@ package com.facebook.nifty.client;
 import com.google.common.net.HostAndPort;
 import org.jboss.netty.util.Timer;
 
-import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NettyClientConfigBuilder.java
@@ -21,17 +21,12 @@ import com.google.common.base.Strings;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
-
 import org.jboss.netty.channel.socket.nio.NioSocketChannelConfig;
-import org.jboss.netty.util.HashedWheelTimer;
-import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.Timer;
 
 import java.lang.reflect.Proxy;
-import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
 

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyAsyncClientTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyAsyncClientTransport.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * This already has a built in TFramedTransport. No need to wrap.
  */
 @NotThreadSafe
-public class TNiftyAsyncClientTransport extends TTransport
+class TNiftyAsyncClientTransport extends TTransport
         implements ChannelUpstreamHandler, ChannelDownstreamHandler
 {
     private static final int DEFAULT_BUFFER_SIZE = 1024;

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientChannelTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientChannelTransport.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.client;
+
+import com.facebook.nifty.core.TChannelBufferInputTransport;
+import com.facebook.nifty.core.TChannelBufferOutputTransport;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.thrift.TException;
+import org.apache.thrift.TServiceClient;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Maps.newHashMap;
+
+@NotThreadSafe
+public class TNiftyClientChannelTransport extends TTransport
+{
+    private final Class<? extends TServiceClient> clientClass;
+    private final NiftyClientChannel channel;
+    private final Map<String, Boolean> methodNameToOneWay;
+    private final TChannelBufferOutputTransport requestBufferTransport;
+    private final TChannelBufferInputTransport responseBufferTransport;
+    private final BlockingQueue<ResponseListener> queuedResponses;
+
+    public TNiftyClientChannelTransport(
+            Class<? extends TServiceClient> clientClass, NiftyClientChannel channel)
+    {
+        this.clientClass = clientClass;
+        this.channel = channel;
+
+        this.methodNameToOneWay = newHashMap();
+        this.requestBufferTransport = new TChannelBufferOutputTransport();
+        this.responseBufferTransport = new TChannelBufferInputTransport(ChannelBuffers.buffer(0));
+        this.queuedResponses = Queues.newLinkedBlockingQueue();
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return channel.getNettyChannel().isOpen();
+    }
+
+    @Override
+    public void open()
+            throws TTransportException
+    {
+        if (!isOpen()) {
+            throw new IllegalStateException("TNiftyClientChannelTransport requires an already-opened channel");
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        channel.close();
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len)
+            throws TTransportException
+    {
+        if (!responseBufferTransport.isReadable()) {
+            try {
+                // If our existing response transport doesn't have any bytes remaining to read,
+                // wait for the next queued response to arrive, and point our response transport
+                // to that.
+                ResponseListener listener = queuedResponses.take();
+                ChannelBuffer response = listener.getResponse().get();
+
+                // Ensure the response buffer is not zero-sized
+                checkState(response.readable(), "Received an empty response");
+
+                responseBufferTransport.setInputBuffer(response);
+            }
+            catch (InterruptedException e) {
+                // Waiting for response was interrupted
+                Thread.currentThread().interrupt();
+                throw new TTransportException(e);
+            }
+            catch (ExecutionException e) {
+                // Error while waiting for response
+                Throwables.propagateIfInstanceOf(e, TTransportException.class);
+                throw new TTransportException(e);
+            }
+        }
+
+        // Read as many bytes as we can (up to the amount requested) from the response
+        return responseBufferTransport.read(buf, off, len);
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len)
+            throws TTransportException
+    {
+        // Write the buffer into the output transport
+        requestBufferTransport.write(buf, off, len);
+    }
+
+    @Override
+    public void flush()
+            throws TTransportException
+    {
+        try {
+            boolean sendOneWay = inOneWayRequest();
+            ResponseListener listener = new ResponseListener();
+            channel.sendAsynchronousRequest(requestBufferTransport.getOutputBuffer().copy(), sendOneWay, listener);
+            queuedResponses.add(listener);
+            requestBufferTransport.resetOutputBuffer();
+        }
+        catch (TException e) {
+            Throwables.propagateIfInstanceOf(e, TTransportException.class);
+            throw new TTransportException(TTransportException.UNKNOWN, "Failed to use reflection on Client class to determine whether method is oneway", e);
+        }
+    }
+
+    private boolean inOneWayRequest()
+            throws TException
+    {
+        boolean isOneWayMethod = false;
+
+        // Create a temporary transport wrapping the output buffer, so that we can read the method name for this message
+        TChannelBufferInputTransport requestReadTransport = new TChannelBufferInputTransport(requestBufferTransport.getOutputBuffer().duplicate());
+        TProtocol protocol = channel.getProtocolFactory().getOutputProtocolFactory().getProtocol(requestReadTransport);
+        TMessage message = protocol.readMessageBegin();
+        String methodName = message.name;
+
+        isOneWayMethod = clientClassHasReceiveHelperMethod(methodName);
+
+        return isOneWayMethod;
+    }
+
+    private boolean clientClassHasReceiveHelperMethod(String methodName)
+    {
+        boolean isOneWayMethod = false;
+
+        if (!methodNameToOneWay.containsKey(methodName)) {
+            try {
+                // HACK! We need to know whether the function is one-way, so we can tell the channel
+                // whether to setup a response callback, but an implementation of TTransport doesn't
+                // normally get this information, so we use reflection to look for a method like
+                // 'recv_foo' which will only be generated for two-way functions.
+                //
+                // We should fix this by getting flushMessage()/flushOneWayMessage() added to
+                // TTransport.
+                clientClass.getMethod("recv_" + methodName);
+            }
+            catch (NoSuchMethodException e) {
+                isOneWayMethod = true;
+            }
+
+            // cache result so we don't use reflection every time
+            methodNameToOneWay.put(methodName, isOneWayMethod);
+        }
+        else  {
+            isOneWayMethod = methodNameToOneWay.get(methodName);
+        }
+        return isOneWayMethod;
+    }
+
+    private static class ResponseListener implements NiftyClientChannel.Listener
+    {
+        private final SettableFuture<ChannelBuffer> response;
+
+        private ResponseListener()
+        {
+            this.response = SettableFuture.create();
+        }
+
+        @Override
+        public void onRequestSent()
+        {
+        }
+
+        @Override
+        public void onResponseReceived(ChannelBuffer response)
+        {
+            this.response.set(response);
+        }
+
+        @Override
+        public void onChannelError(TException cause)
+        {
+            response.setException(new TTransportException(TTransportException.UNKNOWN, cause));
+        }
+
+        public ListenableFuture<ChannelBuffer> getResponse()
+        {
+            return response;
+        }
+    }
+}

--- a/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientTransport.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/TNiftyClientTransport.java
@@ -36,7 +36,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * You should just use a TSocket for sync client.
  * <p/>
  * This already has a built in TFramedTransport. No need to wrap.
+ *
+ * @deprecated Use {@link com.facebook.nifty.client.TNiftyClientChannelTransport} instead
  */
+@Deprecated
 public class TNiftyClientTransport extends TNiftyAsyncClientTransport
 {
 

--- a/nifty-core/src/main/java/com/facebook/nifty/core/TChannelBufferInputTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TChannelBufferInputTransport.java
@@ -73,4 +73,8 @@ public class TChannelBufferInputTransport extends TTransport {
     public void setInputBuffer(ChannelBuffer inputBuffer) {
         this.inputBuffer = inputBuffer;
     }
+
+    public boolean isReadable() {
+        return inputBuffer.readable();
+    }
 }

--- a/nifty-core/src/main/java/com/facebook/nifty/guice/NiftyModule.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/guice/NiftyModule.java
@@ -16,7 +16,6 @@
 package com.facebook.nifty.guice;
 
 import com.facebook.nifty.core.NettyServerConfig;
-import com.facebook.nifty.core.NettyServerConfigBuilder;
 import com.facebook.nifty.core.ThriftServerDef;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;

--- a/nifty-examples/pom.xml
+++ b/nifty-examples/pom.xml
@@ -123,6 +123,16 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <!-- Examples don't need to be deployed -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClient.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.nifty.server;
 
+import com.facebook.nifty.client.FramedClientConnector;
 import com.facebook.nifty.client.NiftyClient;
 import com.facebook.nifty.server.util.ScopedNiftyServer;
 import com.facebook.nifty.test.LogEntry;
@@ -23,6 +24,7 @@ import com.facebook.nifty.test.scribe;
 import com.google.common.base.Throwables;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.jboss.netty.logging.InternalLoggerFactory;
 import org.jboss.netty.logging.Slf4JLoggerFactory;
@@ -84,6 +86,9 @@ public class TestNiftyClient
                     log.info("caught expected exception " + e.toString());
                     exceptionCount++;
                 }
+                catch (Throwable t) {
+                    log.info("caught unexpected exception " + t.toString());
+                }
             }
             Assert.assertTrue(exceptionCount > 0);
 
@@ -113,7 +118,10 @@ public class TestNiftyClient
             throws TTransportException, InterruptedException
     {
         InetSocketAddress address = new InetSocketAddress("localhost", server.getPort());
-        TBinaryProtocol tp = new TBinaryProtocol(niftyClient.connectSync(address));
+        FramedClientConnector framedClientConnector = new FramedClientConnector(address);
+        TTransport transport = niftyClient.connectSync(scribe.Client.class, framedClientConnector);
+        //TTransport transport = niftyClient.connectSync(address);
+        TBinaryProtocol tp = new TBinaryProtocol(transport);
         return new scribe.Client(tp);
     }
 }

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyClientTimeout.java
@@ -18,6 +18,7 @@ package com.facebook.nifty.server;
 import com.facebook.nifty.client.FramedClientChannel;
 import com.facebook.nifty.client.FramedClientConnector;
 import com.facebook.nifty.client.NiftyClient;
+import com.facebook.nifty.test.scribe;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
@@ -69,8 +70,10 @@ public class TestNiftyClientTimeout
         int port = serverSocket.getLocalPort();
         final NiftyClient client = new NiftyClient();
         try {
-                client.connectSync(new InetSocketAddress(port),
+                client.connectSync(scribe.Client.class,
+                                   new FramedClientConnector(new InetSocketAddress(port)),
                                    TEST_CONNECT_TIMEOUT,
+                                   TEST_RECEIVE_TIMEOUT,
                                    TEST_READ_TIMEOUT,
                                    TEST_SEND_TIMEOUT,
                                    TEST_MAX_FRAME_SIZE);

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyServer.java
@@ -15,13 +15,20 @@
  */
 package com.facebook.nifty.server;
 
+import com.facebook.nifty.client.FramedClientConnector;
 import com.facebook.nifty.client.NiftyClient;
-import com.facebook.nifty.core.*;
+import com.facebook.nifty.core.NettyServerConfig;
+import com.facebook.nifty.core.NettyServerTransport;
+import com.facebook.nifty.core.RequestContext;
+import com.facebook.nifty.core.RequestContexts;
+import com.facebook.nifty.core.ThriftServerDefBuilder;
 import com.facebook.nifty.test.LogEntry;
 import com.facebook.nifty.test.ResultCode;
 import com.facebook.nifty.test.scribe;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
 import org.jboss.netty.logging.InternalLoggerFactory;
@@ -98,8 +105,9 @@ public class TestNiftyServer
             throws TTransportException, InterruptedException
     {
         InetSocketAddress address = new InetSocketAddress("localhost", port);
-        TBinaryProtocol tp = new TBinaryProtocol(new NiftyClient().connectSync(address));
-        return new scribe.Client(tp);
+        TTransport transport = new NiftyClient().connectSync(scribe.Client.class, new FramedClientConnector(address));
+        TProtocol protocol = new TBinaryProtocol(transport);
+        return new scribe.Client(protocol);
     }
 
     @Test

--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.nifty.server;
 
+import com.facebook.nifty.client.FramedClientConnector;
 import com.facebook.nifty.client.NiftyClient;
 import com.facebook.nifty.core.NiftyBootstrap;
 import com.facebook.nifty.core.RequestContext;
@@ -31,6 +32,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.jboss.netty.logging.InternalLoggerFactory;
 import org.jboss.netty.logging.Slf4JLoggerFactory;
@@ -126,7 +128,8 @@ public class TestPlainServer
             throws TTransportException, InterruptedException
     {
         InetSocketAddress address = new InetSocketAddress("localhost", port);
-        TBinaryProtocol tp = new TBinaryProtocol(new NiftyClient().connectSync(address));
+        TTransport transport = new NiftyClient().connectSync(scribe.Client.class, new FramedClientConnector(address));
+        TBinaryProtocol tp = new TBinaryProtocol(transport);
         return new scribe.Client(tp);
     }
 


### PR DESCRIPTION
Adds a TNiftyClientChannelTransport for implementing a synchronous TTransport interface on a netty-based asynchronous NiftyClientChannel (this replaces the old framed-only sync wrapper around raw netty async).
