### PR TITLE
Use an independent readerIndex when adapting a TTransport from a ChannelBuffer

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/TChannelBufferInputTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TChannelBufferInputTransport.java
@@ -40,7 +40,7 @@ public class TChannelBufferInputTransport extends TTransport {
     }
 
     public TChannelBufferInputTransport(ChannelBuffer inputBuffer) {
-        this.inputBuffer = inputBuffer;
+        setInputBuffer(inputBuffer);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class TChannelBufferInputTransport extends TTransport {
     }
 
     public void setInputBuffer(ChannelBuffer inputBuffer) {
-        this.inputBuffer = inputBuffer;
+        this.inputBuffer = inputBuffer.duplicate();
     }
 
     public boolean isReadable() {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
@@ -42,7 +42,7 @@ public class TNiftyTransport extends TTransport
                            ThriftTransportType thriftTransportType)
     {
         this.channel = channel;
-        this.in = in;
+        this.in = in.duplicate();
         this.thriftTransportType = thriftTransportType;
         this.out = ChannelBuffers.dynamicBuffer(DEFAULT_OUTPUT_BUFFER_SIZE);
         this.initialReaderIndex = in.readerIndex();


### PR DESCRIPTION
We have some code that wants to adapt a TNiftyTransport around an incoming ChannelBuffer to pre-process it, without affecting the read index of the buffer. To do this, TNiftyTransport (and TChannelBufferInputTransport as well) should call duplicate() on the ChannelBuffers they use for input. Doing this should be cheap, because it doesn't duplicate the memory, only makes a new ChannelBuffer wrapper around the same memory, with different reader/writer indices.
