### PR TITLE
Fix test breaks from my last change

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/TChannelBufferInputTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TChannelBufferInputTransport.java
@@ -71,7 +71,7 @@ public class TChannelBufferInputTransport extends TTransport {
     }
 
     public void setInputBuffer(ChannelBuffer inputBuffer) {
-        this.inputBuffer = inputBuffer.duplicate();
+        this.inputBuffer = inputBuffer;
     }
 
     public boolean isReadable() {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/TNiftyTransport.java
@@ -42,7 +42,7 @@ public class TNiftyTransport extends TTransport
                            ThriftTransportType thriftTransportType)
     {
         this.channel = channel;
-        this.in = in.duplicate();
+        this.in = in;
         this.thriftTransportType = thriftTransportType;
         this.out = ChannelBuffers.dynamicBuffer(DEFAULT_OUTPUT_BUFFER_SIZE);
         this.initialReaderIndex = in.readerIndex();
@@ -56,6 +56,11 @@ public class TNiftyTransport extends TTransport
             buffer = in.array();
             initialBufferPosition = bufferPosition = in.arrayOffset() + in.readerIndex();
             bufferEnd = bufferPosition + in.readableBytes();
+            // Without this, reading from a !in.hasArray() buffer will advance the readerIndex
+            // of the buffer, while reading from a in.hasArray() buffer will not advance the
+            // readerIndex, and this has led to subtle bugs. This should help to identify
+            // those problems by making things more consistent.
+            in.readerIndex(in.readerIndex() + in.readableBytes());
         }
     }
 


### PR DESCRIPTION
Some callers actually wanted to create a transport around a ChannelBuffer in order to traverse through the data in the buffer and figure out how many bytes were read. If the buffer is duplicated internally, they can't check how many bytes were read without providing access to the duplicated buffer. In the end I decided to switch things back to how they were, and the code that actually _did_ want the buffer duplicated (to do some pre-processing of the message before sending it to the actual processor) will do so explicitly.
