### PR TITLE
Add handling for RejectedExecutionException

### DIFF
--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestPlainServer.java
@@ -17,6 +17,8 @@ package com.facebook.nifty.server;
 
 import com.facebook.nifty.client.FramedClientConnector;
 import com.facebook.nifty.client.NiftyClient;
+import com.facebook.nifty.core.NettyServerConfig;
+import com.facebook.nifty.core.NettyServerConfigBuilder;
 import com.facebook.nifty.core.NiftyBootstrap;
 import com.facebook.nifty.core.RequestContext;
 import com.facebook.nifty.core.RequestContexts;
@@ -25,11 +27,18 @@ import com.facebook.nifty.guice.NiftyModule;
 import com.facebook.nifty.test.LogEntry;
 import com.facebook.nifty.test.ResultCode;
 import com.facebook.nifty.test.scribe;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Guice;
+import com.google.inject.Provider;
 import com.google.inject.Stage;
 import io.airlift.units.Duration;
+import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
+import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
@@ -47,7 +56,14 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public class TestPlainServer
 {
@@ -115,13 +131,64 @@ public class TestPlainServer
         client.Log(Arrays.asList(new LogEntry("hello", "world")));
     }
 
+    @Test
+    public void testRejectedExecution()
+            throws InterruptedException, TException
+    {
+        BlockingQueue<Runnable> queue = new ArrayBlockingQueue<>(1);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS, queue);
+        final TProcessor defaultProcessor = defaultProcessor();
+        TProcessor slowProcessor = new TProcessor()
+        {
+            @Override
+            public boolean process(
+                    TProtocol in, TProtocol out)
+                    throws TException
+            {
+                Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
+                return defaultProcessor.process(in, out);
+            }
+        };
+        startServer(getThriftServerDefBuilder().using(executor).withProcessor(slowProcessor));
+
+        scribe.Client client1 = makeClient();
+        scribe.Client client2 = makeClient();
+        scribe.Client client3 = makeClient();
+
+        List<LogEntry> messages = ImmutableList.of(new LogEntry("hello", "world"));
+
+        client1.send_Log(messages);
+        Uninterruptibles.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+        client2.send_Log(messages);
+        Uninterruptibles.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+        client3.send_Log(messages);
+
+        client1.recv_Log();
+        client2.recv_Log();
+
+        try {
+            client3.recv_Log();
+            fail("Third call should have failed because server queue is too short");
+        }
+        catch (TApplicationException ex)
+        {
+            // expected behavior:
+            // - first call is not queued, goes directly to a worker thread on the executor
+            // - second call is queued, filling the queue which has a fixed length of 1
+            // - third call is rejected, we should receive an INTERNAL_ERROR
+            assertEquals(ex.getType(), TApplicationException.INTERNAL_ERROR);
+        }
+    }
+
     private scribe.Client makeClient()
             throws TTransportException
     {
         TSocket socket = new TSocket("localhost", port);
         socket.open();
-        TBinaryProtocol tp = new TBinaryProtocol(new TFramedTransport(socket));
-        return new scribe.Client(tp);
+        socket.setTimeout(1000);
+        TBinaryProtocol in = new TBinaryProtocol(new TFramedTransport(socket));
+        TBinaryProtocol out = new TBinaryProtocol(new TFramedTransport(socket));
+        return new scribe.Client(in, out);
     }
 
     private scribe.Client makeNiftyClient()
@@ -141,12 +208,25 @@ public class TestPlainServer
 
     private void startServer(final ThriftServerDefBuilder thriftServerDefBuilder)
     {
-        bootstrap = Guice.createInjector(Stage.PRODUCTION, new NiftyModule() {
-            @Override
-            protected void configureNifty() {
-                bind().toInstance(thriftServerDefBuilder.build());
-            }
-        }).getInstance(NiftyBootstrap.class);
+        bootstrap = Guice.createInjector(
+                Stage.PRODUCTION,
+                new NiftyModule()
+                {
+                    @Override
+                    protected void configureNifty()
+                    {
+                        bind().toInstance(thriftServerDefBuilder.build());
+                        withNettyServerConfig(new Provider<NettyServerConfig>()
+                        {
+                            @Override
+                            public NettyServerConfig get()
+                            {
+                                return new NettyServerConfigBuilder().setWorkerThreadCount(1).build();
+                            }
+                        });
+                    }
+                }
+        ).getInstance(NiftyBootstrap.class);
 
         bootstrap.start();
     }
@@ -165,20 +245,26 @@ public class TestPlainServer
 
         return new ThriftServerDefBuilder()
                 .listen(port)
-                .withProcessor(new scribe.Processor<>(new scribe.Iface() {
-                    @Override
-                    public ResultCode Log(List<LogEntry> messages)
-                            throws TException {
-                        RequestContext context = RequestContexts.getCurrentContext();
+                .withProcessor(defaultProcessor());
+    }
 
-                        for (LogEntry message : messages) {
-                            log.info("[Client: {}] {}: {}",
-                                     context.getConnectionContext().getRemoteAddress(),
-                                     message.getCategory(),
-                                     message.getMessage());
-                        }
-                        return ResultCode.OK;
-                    }
-                }));
+    private scribe.Processor<scribe.Iface> defaultProcessor()
+    {
+        return new scribe.Processor<scribe.Iface>(new scribe.Iface() {
+            @Override
+            public ResultCode Log(List<LogEntry> messages)
+                    throws TException
+            {
+                RequestContext context = RequestContexts.getCurrentContext();
+
+                for (LogEntry message : messages) {
+                    log.info("[Client: {}] {}: {}",
+                             context.getConnectionContext().getRemoteAddress(),
+                             message.getCategory(),
+                             message.getMessage());
+                }
+                return ResultCode.OK;
+            }
+        });
     }
 }


### PR DESCRIPTION
Send a TApplicationException response (and don't process the request) when the server is configured with an executor that has a limited-size queue, and a request arrives but the queue is full.
