### PR TITLE
AbstractClientChannel should not swallow inner exceptions

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/AbstractClientChannel.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/AbstractClientChannel.java
@@ -260,8 +260,8 @@ public abstract class AbstractClientChannel extends SimpleChannelHandler impleme
             throws Exception
     {
         Throwable t = event.getCause();
-        ctx.getChannel().close();
         onError(t);
+        ctx.getChannel().close();
     }
 
     private Request makeRequest(int sequenceId, Listener listener)


### PR DESCRIPTION
Nifty swallows inner exceptions and rethrows TTransportException with "Client was disconnected by server", which is misleading and it causes debugging to be really hard. This is to switch the order of the calls so that we can keep the original exception for better debugging.
