### PR TITLE
Move ClientRequestContext to nifty-client and add getRequestChannel

### DIFF
--- a/nifty-client/src/main/java/com/facebook/nifty/client/ClientRequestContext.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/ClientRequestContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.nifty.core;
+package com.facebook.nifty.client;
 
 import org.apache.thrift.protocol.TProtocol;
 
@@ -25,5 +25,7 @@ public interface ClientRequestContext
 
     TProtocol getInputProtocol();
 
-    public SocketAddress getRemoteAddress();
+    RequestChannel getRequestChannel();
+
+    SocketAddress getRemoteAddress();
 }

--- a/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientRequestContext.java
+++ b/nifty-client/src/main/java/com/facebook/nifty/client/NiftyClientRequestContext.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.nifty.core;
+package com.facebook.nifty.client;
 
 import org.apache.thrift.protocol.TProtocol;
 
@@ -22,12 +22,17 @@ import java.net.SocketAddress;
 public class NiftyClientRequestContext implements ClientRequestContext{
     private final TProtocol inputProtocol;
     private final TProtocol outputProtocol;
+    private final RequestChannel requestChannel;
     private final SocketAddress remoteAddress;
 
-    public NiftyClientRequestContext(TProtocol inputProtocol, TProtocol outputProtocol, SocketAddress remoteAddress)
+    public NiftyClientRequestContext(TProtocol inputProtocol,
+                                     TProtocol outputProtocol,
+                                     RequestChannel requestChannel,
+                                     SocketAddress remoteAddress)
     {
         this.inputProtocol = inputProtocol;
         this.outputProtocol = outputProtocol;
+        this.requestChannel = requestChannel;
         this.remoteAddress = remoteAddress;
     }
 
@@ -41,6 +46,12 @@ public class NiftyClientRequestContext implements ClientRequestContext{
     public TProtocol getInputProtocol()
     {
         return inputProtocol;
+    }
+
+    @Override
+    public RequestChannel getRequestChannel()
+    {
+        return requestChannel;
     }
 
     @Override


### PR DESCRIPTION
Summary: This is for http clients. Http client uses binary protocol and
the context can use the RequestChannel's type to determine if it is a
HttpClient and set its headers.
