### PR TITLE
Add in queueTimeout support to nifty

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDef.java
@@ -36,6 +36,7 @@ public class ThriftServerDef
 
     private final Duration clientIdleTimeout;
     private final Duration taskTimeout;
+    private final Duration queueTimeout;
 
     private final ThriftFrameCodecFactory thriftFrameCodecFactory;
     private final Executor executor;
@@ -52,6 +53,7 @@ public class ThriftServerDef
             TDuplexProtocolFactory duplexProtocolFactory,
             Duration clientIdleTimeout,
             Duration taskTimeout,
+            Duration queueTimeout,
             ThriftFrameCodecFactory thriftFrameCodecFactory,
             Executor executor,
             NiftySecurityFactory securityFactory)
@@ -65,6 +67,7 @@ public class ThriftServerDef
         this.duplexProtocolFactory = duplexProtocolFactory;
         this.clientIdleTimeout = clientIdleTimeout;
         this.taskTimeout = taskTimeout;
+        this.queueTimeout = queueTimeout;
         this.thriftFrameCodecFactory = thriftFrameCodecFactory;
         this.executor = executor;
         this.securityFactory = securityFactory;
@@ -110,6 +113,8 @@ public class ThriftServerDef
     }
 
     public Duration getTaskTimeout() { return taskTimeout; }
+
+    public Duration getQueueTimeout() { return queueTimeout; }
 
     public Executor getExecutor()
     {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilderBase.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/ThriftServerDefBuilderBase.java
@@ -60,6 +60,7 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
     private String name = "nifty-" + ID.getAndIncrement();
     private Duration clientIdleTimeout;
     private Duration taskTimeout;
+    private Duration queueTimeout;
     private NiftySecurityFactory securityFactory;
 
     /**
@@ -91,6 +92,7 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
         };
         this.clientIdleTimeout = null;
         this.taskTimeout = null;
+        this.queueTimeout = null;
         this.thriftFrameCodecFactory = new DefaultThriftFrameCodecFactory();
         this.securityFactory = new NiftyNoOpSecurityFactory();
     }
@@ -216,6 +218,16 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
         return (T) this;
     }
 
+    /**
+     * Specify timeout during which if a task remains on the executor queue, server will cancel the
+     *    task when it is dispatched.  The timeout is the minimum of taskTimeout and queueTimeout
+     */
+    public T queueTimeout(Duration queueTimeout)
+    {
+        this.queueTimeout = queueTimeout;
+        return (T) this;
+    }
+
     public T thriftFrameCodecFactory(ThriftFrameCodecFactory thriftFrameCodecFactory)
     {
         this.thriftFrameCodecFactory = thriftFrameCodecFactory;
@@ -265,6 +277,7 @@ public abstract class ThriftServerDefBuilderBase<T extends ThriftServerDefBuilde
                 duplexProtocolFactory,
                 clientIdleTimeout,
                 taskTimeout,
+                queueTimeout,
                 thriftFrameCodecFactory,
                 executor,
                 securityFactory);


### PR DESCRIPTION
Tuning load shedding via a fixed queue size is difficult, especially in heterogeneous workloads. Adding a queue timeout of let's say 100ms will allow a server to shed work if it is backing up while still being able to perform meaningful work that clients are actually waiting on and haven't timed out already.

Tasks are expired off the queue in the minimum of queueTimeout or taskTimeout. By default queueTimeout is configured to be 0 which makes this diff a noop. 
