### PR TITLE
Fix leak in sslengine

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/ssl/SslPlaintextHandler.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/ssl/SslPlaintextHandler.java
@@ -38,6 +38,10 @@ public class SslPlaintextHandler extends FrameDecoder {
 
         if (looksLikeTLS(buffer)) {
             ctx.getPipeline().addAfter(ctx.getName(), sslHandlerName, sslHandler);
+        } else {
+            // If the SSL handler is not used, close the ssl engine. This will clean up any native structures
+            // that the ssl engine holds on to.
+            sslHandler.getEngine().closeOutbound();
         }
 
         ctx.getPipeline().remove(this);


### PR DESCRIPTION
In case of the openssl provider, if the ssl engine is unused, then it will leak some structures like Bio and SSL that were allocated in initialization. This makes it so that we clean them up if peeking fails and we are never going to use the Sslhandler.
