### PR TITLE
add ticket seed parser

### DIFF
--- a/nifty-ssl/pom.xml
+++ b/nifty-ssl/pom.xml
@@ -54,5 +54,21 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/CryptoUtil.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/CryptoUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.ssl;
+
+import org.apache.commons.codec.digest.HmacUtils;
+
+import javax.crypto.Mac;
+
+public class CryptoUtil {
+
+    public static final int SHA2_BYTES = 32;
+    private static final int MAX_OUTPUT_LENGTH = SHA2_BYTES * 255;
+    private static final byte[] nullSalt = new byte[SHA2_BYTES];
+
+    private static byte[] hmacHash(byte[] prk, byte[] data) {
+        Mac mac = HmacUtils.getHmacSha256(prk);
+        return mac.doFinal(data);
+    }
+
+    private static byte[] hmacHash(byte[] prk, byte[] data, byte[] info, byte count) {
+        Mac mac = HmacUtils.getHmacSha256(prk);
+        if (data != null) {
+            mac.update(data);
+        }
+        mac.update(info);
+        mac.update(count);
+        return mac.doFinal();
+    }
+
+    public static byte[] hkdf(byte[] info, byte[] key, byte[] salt, int outputLength) {
+        if (outputLength > MAX_OUTPUT_LENGTH) {
+            throw new IllegalArgumentException("Output length too large " + outputLength);
+        }
+
+        if (salt == null) {
+            salt = nullSalt;
+        }
+        byte[] prk = hmacHash(salt, key);
+
+        int N = (int) Math.ceil(outputLength / SHA2_BYTES);
+        byte[] outputData = new byte[outputLength];
+
+        int idx = 0;
+        byte[] current = null;
+
+        for (int i = 1; i <= N + 1; ++i) {
+            byte counter = (byte) i;
+            current = hmacHash(prk, current, info, counter);
+            System.arraycopy(current, 0, outputData, idx, Math.min(SHA2_BYTES, outputLength - idx));
+            idx += SHA2_BYTES;
+        }
+        return outputData;
+    }
+}

--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/TicketSeedParser.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/TicketSeedParser.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.ssl;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.tomcat.jni.SessionTicketKey;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+/**
+ * To make distribution of ticket keys and rotating ticket keys easier, tickets can be distributed
+ * as a seed file in the following format
+ * {
+ *     "current": ["5afc6fb03ba4b15", "9547a3ab68b440ef7"],
+ *     "new": ["5afc6fb03ba4b15", "9547a3ab68b440ef7"],
+ *     "old": ["5afc6fb03ba4b15", "9547a3ab68b440ef7"]
+ * }
+ *
+ * The real ticket keys are generated from the seeds. The seeds can be arbitrary length hex encoded values.
+ * The current seeds are used to generate new tickets, and tickets encrypted with the old and new keys are
+ * accepted to allow for some leeway in rotation of tickets.
+ *
+ * The algorithm used to compute the session ticket encryption keys is the following:
+ *
+ * aesKey  = hkdf(seed, "aes")  -> truncated to AES bytes.
+ * hmacKey = hkdf(seed, "hmac") -> truncated to HMAC bytes
+ * name    = hkdf(seed, "name") -> truncated to name bytes
+ */
+public class TicketSeedParser {
+
+    public static byte[] defaultTicketSalt;
+    private static byte[] nameBytes = "name".getBytes();
+    private static byte[] aesBytes = "aes".getBytes();
+    private static byte[] hmacBytes = "hmac".getBytes();
+
+    static {
+        /*
+         * Randomly generated salt to use for the purpose of ticket seeds. The salt in the HKDF is meant to be public.
+         * We do not want to use a random salt so that every machine that gets the same seed will compute the same
+         * ticket keys.
+         */
+        try {
+            defaultTicketSalt = Hex.decodeHex("b78973d13c2d0eb24cf94cd692239867".toCharArray());
+        }
+        catch (DecoderException e) {
+            // This is a fatal error.
+            Throwables.propagate(e);
+        }
+    }
+
+    class SeedSpec {
+        @SerializedName("current")
+        String[] currentSeeds;
+        @SerializedName("new")
+        String[] newSeeds;
+        @SerializedName("old")
+        String[] oldSeeds;
+    }
+
+    private static SeedSpec getSeedSpec(File file) throws IOException {
+        Gson gson = new Gson();
+        try (Reader reader = Files.newReader(file, Charset.defaultCharset())) {
+            SeedSpec spec = gson.fromJson(reader, SeedSpec.class);
+            return spec;
+        } catch (JsonSyntaxException|JsonIOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static SessionTicketKey deriveKeyFromSeed(String seed) throws DecoderException {
+        byte[] seedBin = Hex.decodeHex(seed.toCharArray());
+        byte[] keyName = CryptoUtil.hkdf(nameBytes, seedBin, defaultTicketSalt, SessionTicketKey.NAME_SIZE);
+        byte[] aesKey = CryptoUtil.hkdf(aesBytes, seedBin, defaultTicketSalt, SessionTicketKey.AES_KEY_SIZE);
+        byte[] hmacKey = CryptoUtil.hkdf(hmacBytes, seedBin, defaultTicketSalt, SessionTicketKey.HMAC_KEY_SIZE);
+        return new SessionTicketKey(keyName, hmacKey, aesKey);
+    }
+
+    /**
+     * Returns a list of tickets parsed from the ticket file. The keys are returned in a format suitable for use
+     * with netty. The first keys are the current keys, following that are the old and new keys.
+     */
+    public static SessionTicketKey[] parse(File file) throws IOException, DecoderException, IllegalArgumentException {
+        SeedSpec spec = getSeedSpec(file);
+        if (spec.currentSeeds == null || spec.currentSeeds.length == 0) {
+            throw new IllegalArgumentException("current seeds must exist");
+        }
+        int numSeeds = spec.currentSeeds.length;
+        if (spec.newSeeds != null) {
+            numSeeds += spec.newSeeds.length;
+        }
+        if (spec.oldSeeds != null) {
+            numSeeds += spec.oldSeeds.length;
+        }
+        SessionTicketKey[] keys = new SessionTicketKey[numSeeds];
+        int idx = 0;
+        for (String seed : spec.currentSeeds) {
+            keys[idx++] = deriveKeyFromSeed(seed);
+        }
+        if (spec.newSeeds != null) {
+            for (String seed : spec.newSeeds) {
+                keys[idx++] = deriveKeyFromSeed(seed);
+            }
+        }
+        if (spec.oldSeeds != null) {
+            for (String seed : spec.oldSeeds) {
+                keys[idx++] = deriveKeyFromSeed(seed);
+            }
+        }
+        return keys;
+    }
+}

--- a/nifty-ssl/src/test/java/com/facebook/nifty/ssl/CryptoUtilTest.java
+++ b/nifty-ssl/src/test/java/com/facebook/nifty/ssl/CryptoUtilTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.ssl;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CryptoUtilTest {
+
+    class TestVector {
+        String key;
+        String salt;
+        String info;
+        String expected;
+    }
+
+    // Test cases taken from https://tools.ietf.org/html/rfc5869
+    public void validateVector(TestVector vector) throws DecoderException {
+        byte[] key = Hex.decodeHex(vector.key.toCharArray());
+        byte[] salt = null;
+        if (!vector.salt.isEmpty()) {
+            salt = Hex.decodeHex(vector.salt.toCharArray());
+        }
+        byte[] info = null;
+        if (!vector.info.isEmpty()) {
+            info = Hex.decodeHex(vector.info.toCharArray());
+        }
+        byte[] expected = Hex.decodeHex(vector.expected.toCharArray());
+        byte[] actual = CryptoUtil.hkdf(info, key, salt, expected.length);
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testHkdf1() throws DecoderException {
+        TestVector vector = new TestVector();
+        vector.key = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b";
+        vector.salt = "000102030405060708090a0b0c";
+        vector.info = "f0f1f2f3f4f5f6f7f8f9";
+        vector.expected = "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865";
+        validateVector(vector);
+    }
+
+    @Test
+    public void testHkdf2() throws DecoderException {
+        TestVector vector = new TestVector();
+        vector.key = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f";
+        vector.salt = "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf";
+        vector.info = "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
+        vector.expected = "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f";
+        validateVector(vector);
+    }
+
+    @Test
+    public void testHkdf3() throws DecoderException {
+        TestVector vector = new TestVector();
+        vector.key = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b";
+        vector.salt = "";
+        vector.info = "";
+        vector.expected = "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8";
+        validateVector(vector);
+    }
+}

--- a/nifty-ssl/src/test/java/com/facebook/nifty/ssl/TicketSeedParserTest.java
+++ b/nifty-ssl/src/test/java/com/facebook/nifty/ssl/TicketSeedParserTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2012-2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.ssl;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.tomcat.jni.SessionTicketKey;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class TicketSeedParserTest {
+
+    @Test
+    public void testParseSeeds() throws IOException, DecoderException {
+        SessionTicketKey[] keys =
+                TicketSeedParser.parse(
+                        new File(TicketSeedParserTest.class.getResource("/good_seeds.json").getFile()));
+        Assert.assertEquals(6, keys.length);
+
+        // The seeds in the file are arranged so that every 2 are the same, and adjacent ones are not.
+        for (int i = 0; i < keys.length / 2; i += 2) {
+            Assert.assertTrue(Arrays.equals(keys[i].getHmacKey(), keys[i + 2].getHmacKey()));
+            Assert.assertTrue(Arrays.equals(keys[i].getName(), keys[i + 2].getName()));
+            Assert.assertTrue(Arrays.equals(keys[i].getAesKey(), keys[i + 2].getAesKey()));
+        }
+        for (int i = 0; i < keys.length - 1; i++) {
+            Assert.assertNotEquals(keys[i].getHmacKey(), keys[i + 1].getHmacKey());
+            Assert.assertNotEquals(keys[i].getName(), keys[i + 1].getName());
+            Assert.assertNotEquals(keys[i].getAesKey(), keys[i + 1].getAesKey());
+        }
+
+        SessionTicketKey[] keys2 =
+                TicketSeedParser.parse(
+                        new File(TicketSeedParserTest.class.getResource("/good_seeds.json").getFile()));
+        Assert.assertEquals(keys.length, keys2.length);
+        for (int i = 0; i < keys.length; ++i) {
+            Assert.assertEquals(keys[i].getAesKey(), keys2[i].getAesKey(), "AES key not equal");
+            Assert.assertEquals(keys[i].getName(), keys2[i].getName());
+            Assert.assertEquals(keys[i].getHmacKey(), keys2[i].getHmacKey());
+        }
+    }
+
+    @Test
+    public void testParseCurrentSeeds() throws IOException, DecoderException {
+        SessionTicketKey[] keys =
+                TicketSeedParser.parse(
+                        new File(TicketSeedParserTest.class.getResource("/seeds_with_only_current.json").getFile()));
+        Assert.assertEquals(2, keys.length);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testParseNoCurrentSeeds() throws IOException, DecoderException {
+        TicketSeedParser.parse(
+                new File(TicketSeedParserTest.class.getResource("/seeds_with_no_current.json").getFile()));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testParseBadJson() throws IOException, DecoderException {
+        TicketSeedParser.parse(
+                new File(TicketSeedParserTest.class.getResource("/seeds_bad_json.json").getFile()));
+    }
+}

--- a/nifty-ssl/src/test/resources/good_seeds.json
+++ b/nifty-ssl/src/test/resources/good_seeds.json
@@ -1,0 +1,5 @@
+{
+  "old": ["aaaaaaaa", "bbbbbbbbbb"],
+  "new": ["aaaaaaaa", "bbbbbbbbbb"],
+  "current": ["aaaaaaaa", "bbbbbbbbbb"]
+}

--- a/nifty-ssl/src/test/resources/seeds_bad_json.json
+++ b/nifty-ssl/src/test/resources/seeds_bad_json.json
@@ -1,0 +1,4 @@
+{
+  "old": ["aaaaaaaa", "bbbbbbbbbb"],
+  "new": ["aaaaaaaa", "bbbbbbbbbb"],
+}

--- a/nifty-ssl/src/test/resources/seeds_with_no_current.json
+++ b/nifty-ssl/src/test/resources/seeds_with_no_current.json
@@ -1,0 +1,4 @@
+{
+  "old": ["aaaaaaaa", "bbbbbbbbbb"],
+  "new": ["aaaaaaaa", "bbbbbbbbbb"]
+}

--- a/nifty-ssl/src/test/resources/seeds_with_only_current.json
+++ b/nifty-ssl/src/test/resources/seeds_with_only_current.json
@@ -1,0 +1,3 @@
+{
+  "current": ["aaaaaaaa", "bbbbbbbbbb"]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,18 @@
                 <artifactId>easymock</artifactId>
                 <version>3.2</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.7</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Parses and creates ticket keys from a ticket seed
file.

A seed file is a file with arbitrary secret hex strings.
These are then expanded to be individual keys like the hmac
and aes key using an hkdf.

To do hex decoding and parsing this adds 2 new deps:
1. gson for json parsing
2. apache codec for hex decoding.
