### PR TITLE
Change decoder

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -130,10 +130,10 @@ public class NettyServerTransport implements ExternalResourceReleasable
 
                 SslServerConfiguration serverConfiguration = sslConfiguration.get();
                 if (serverConfiguration != null) {
-                    SslHandler handler = serverConfiguration.createHandler();
                     if (serverConfiguration.allowPlaintext) {
-                        cp.addFirst("ssl_plaintext", new SslPlaintextHandler(handler, "ssl"));
+                        cp.addFirst("ssl_plaintext", new SslPlaintextHandler(serverConfiguration, "ssl"));
                     } else {
+                        SslHandler handler = serverConfiguration.createHandler();
                         cp.addFirst("ssl", handler);
                     }
                 }

--- a/nifty-core/src/main/java/com/facebook/nifty/ssl/SslPlaintextHandler.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/ssl/SslPlaintextHandler.java
@@ -18,15 +18,14 @@ package com.facebook.nifty.ssl;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.*;
 import org.jboss.netty.handler.codec.frame.FrameDecoder;
-import org.jboss.netty.handler.ssl.SslHandler;
 
 public class SslPlaintextHandler extends FrameDecoder {
 
-    private final SslHandler sslHandler;
+    private final SslServerConfiguration serverConfiguration;
     private final String sslHandlerName;
 
-    public SslPlaintextHandler(SslHandler sslHandler, String sslHandlerName) {
-        this.sslHandler = sslHandler;
+    public SslPlaintextHandler(SslServerConfiguration serverConfiguration, String sslHandlerName) {
+        this.serverConfiguration = serverConfiguration;
         this.sslHandlerName = sslHandlerName;
     }
 
@@ -37,11 +36,7 @@ public class SslPlaintextHandler extends FrameDecoder {
         }
 
         if (looksLikeTLS(buffer)) {
-            ctx.getPipeline().addAfter(ctx.getName(), sslHandlerName, sslHandler);
-        } else {
-            // If the SSL handler is not used, close the ssl engine. This will clean up any native structures
-            // that the ssl engine holds on to.
-            sslHandler.getEngine().closeOutbound();
+            ctx.getPipeline().addAfter(ctx.getName(), sslHandlerName, serverConfiguration.createHandler());
         }
 
         ctx.getPipeline().remove(this);

--- a/nifty-core/src/main/java/com/facebook/nifty/ssl/SslPlaintextHandler.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/ssl/SslPlaintextHandler.java
@@ -40,8 +40,7 @@ public class SslPlaintextHandler extends FrameDecoder {
         }
 
         ctx.getPipeline().remove(this);
-        Channels.fireMessageReceived(ctx, buffer, ctx.getPipeline().getChannel().getRemoteAddress());
-        return null;
+        return buffer.readBytes(buffer.readableBytes());
     }
 
 

--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/BetterSslHandler.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/BetterSslHandler.java
@@ -1,0 +1,28 @@
+package com.facebook.nifty.ssl;
+
+import org.jboss.netty.handler.ssl.OpenSslEngine;
+import org.jboss.netty.handler.ssl.SslBufferPool;
+import org.jboss.netty.handler.ssl.SslHandler;
+
+import javax.net.ssl.SSLEngine;
+
+/**
+ * We're seeing SslEngine leaking in a few places.
+ * This SslHandler uses a finalizer to clean up the SslEngine
+ * correctly like netty 4 does as well.
+ */
+public class BetterSslHandler extends SslHandler {
+
+    private final OpenSslEngine sslEngine;
+
+    public BetterSslHandler(SSLEngine engine, SslBufferPool bufferPool) {
+        super(engine, bufferPool);
+        sslEngine = (OpenSslEngine) engine;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        sslEngine.shutdown();
+        super.finalize();
+    }
+}

--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/NiftyOpenSslServerContext.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/NiftyOpenSslServerContext.java
@@ -302,7 +302,7 @@ public final class NiftyOpenSslServerContext implements SslHandlerFactory {
 
     @Override
     public SslHandler newHandler() {
-        SslHandler handler = new SslHandler(newEngine(), bufferPool);
+        SslHandler handler = new BetterSslHandler(newEngine(), bufferPool);
         handler.setCloseOnSSLException(true);
         return handler;
     }


### PR DESCRIPTION
This pull request adds 3 changes: 
1. Moves Sslhandler to only be initialized if using Ssl. We had this change before, but it got lost because we had to revert some other changes. 
2. We suspect there might be some leak in SslHandler. Netty 4 added a new SslHandler which uses a finalizer to clean up the engine. This does something similar, where we use a handler with a finalizer instead
3. Cleans up the Plaintext switching logic to how it was meant to be used. Returns a channelbuffer instead of firing the message on our own. The FrameDecoder will take care of firing the message for us.
