### PR TITLE
downgrade jackson dependency to 2.4.4 for swift compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
 
         <dep.airlift.version>0.119</dep.airlift.version>
-        <dep.jackson.version>2.8.1</dep.jackson.version>
+        <dep.jackson.version>2.4.4</dep.jackson.version>
     </properties>
 
     <url>https://facebook.github.com/nifty</url>


### PR DESCRIPTION
Swift depends on something that depends on jackson 2.4.4, this had a version conflict with our jackson 2.8.1 dependency. The path of least resistance is to downgrade nifty's jackson dependency to 2.4.4. We use jackson in a very basic way, so either version works fine for nifty.
