### PR TITLE
Add NiftyIODispatcher

### DIFF
--- a/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NettyServerTransport.java
@@ -110,6 +110,7 @@ public class NettyServerTransport implements ExternalResourceReleasable
                 cp.addLast("connectionLimiter", connectionLimiter);
                 cp.addLast(ChannelStatistics.NAME, channelStatistics);
                 cp.addLast("encryptionHandler", securityHandlers.getEncryptionHandler());
+                cp.addLast("ioDispatcher", new NiftyIODispatcher());
                 cp.addLast("frameCodec", def.getThriftFrameCodecFactory().create(def.getMaxFrameSize(),
                                                                                  inputProtocolFactory));
                 if (def.getClientIdleTimeout() != null) {

--- a/nifty-core/src/main/java/com/facebook/nifty/core/NiftyIODispatcher.java
+++ b/nifty-core/src/main/java/com/facebook/nifty/core/NiftyIODispatcher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2012-2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.core;
+
+import org.jboss.netty.channel.ChannelEvent;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.channel.SimpleChannelDownstreamHandler;
+
+/**
+ * Dispatches downstream messages from the worker threads to the IO threads,
+ * so that code in IO threads do not have to worry about downstream paths
+ * being invoked from multiple threads.
+ */
+public class NiftyIODispatcher extends SimpleChannelDownstreamHandler {
+
+    @Override
+    public void handleDownstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception {
+        ctx.getPipeline().execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    NiftyIODispatcher.super.handleDownstream(ctx, e);
+                }
+                catch (Exception ex) {
+                    Channels.fireExceptionCaught(ctx.getChannel(), ex);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Adds a NiftyIODispatcher which serializes downstream
messages that come from worker threads to be back
on the IO threads.

This has some benefits for some classes like SSL which
otherwise have to take locks on the IO thread to deal
with being called from various threads.
