### PR TITLE
Add thread local SslBufferPool

### DIFF
--- a/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyOpenSslServer.java
+++ b/nifty-examples/src/test/java/com/facebook/nifty/server/TestNiftyOpenSslServer.java
@@ -618,6 +618,24 @@ public class TestNiftyOpenSslServer
         Assert.assertEquals(client2.Log(Arrays.asList(new LogEntry("client2", "aaa"))), ResultCode.OK);
     }
 
+    @Test
+    public void testThreadLocalSslBufferPool() throws InterruptedException, IOException, TException {
+        SslServerConfiguration serverConfig = OpenSslServerConfiguration.newBuilder()
+                .certFile(getServerCertFile())
+                .keyFile(getPrivateKeyFile())
+                .allowPlaintext(false)
+                .sslVerification(OpenSslServerConfiguration.SSLVerification.VERIFY_REQUIRE)
+                .clientCAFile(getClientCertFile())
+                .threadLocalSslBuffer(true)
+                .build();
+
+        ThriftServerDefBuilder builder = getThriftServerDefBuilder(serverConfig, null);
+        startServer(builder);
+
+        scribe.Client client = makeNiftyClient(getClientSSLConfiguration(null, getClientKeyManagers()));
+        Assert.assertEquals(client.Log(Arrays.asList(new LogEntry("client", "aaa"))), ResultCode.OK);
+    }
+
     @Test(expectedExceptions = TTransportException.class)
     public void testClientWithoutCerts() throws InterruptedException, IOException, TException {
         SslServerConfiguration serverConfig = OpenSslServerConfiguration.newBuilder()

--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/OpenSslServerConfiguration.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/OpenSslServerConfiguration.java
@@ -62,6 +62,9 @@ public class OpenSslServerConfiguration extends SslServerConfiguration {
         public long sessionTimeoutSeconds = 86400;
         public long sessionCacheSize = 0;
         public boolean enableStatefulSessionCache = true;
+        public int maxSslBufferBytes = 19267584;
+        public boolean preallocateSslBuffer = true;
+        public boolean threadLocalSslBuffer = false;
         public SSLVersion sslVersion = SSLVersion.TLS1_2;
         public Iterable<String> nextProtocols = ImmutableList.of("thrift");
         public File clientCAFile;
@@ -118,6 +121,21 @@ public class OpenSslServerConfiguration extends SslServerConfiguration {
             return this;
         }
 
+        public Builder maxSslBufferBytes(int maxSslBufferBytes) {
+            this.maxSslBufferBytes = maxSslBufferBytes;
+            return this;
+        }
+
+        public Builder preallocateSslBuffer(boolean preallocateSslBuffer) {
+            this.preallocateSslBuffer = preallocateSslBuffer;
+            return this;
+        }
+
+        public Builder threadLocalSslBuffer(boolean threadLocalSslBuffer) {
+            this.threadLocalSslBuffer = threadLocalSslBuffer;
+            return this;
+        }
+
         /**
          * Copies the state of an existing configration into this builder.
          * @param config the SSL configuration.
@@ -133,6 +151,9 @@ public class OpenSslServerConfiguration extends SslServerConfiguration {
                 sessionTimeoutSeconds(openSslConfig.sessionTimeoutSeconds);
                 sessionCacheSize(openSslConfig.sessionCacheSize);
                 enableStatefulSessionCache(openSslConfig.enableStatefulSessionCache);
+                maxSslBufferBytes(openSslConfig.maxSslBufferBytes);
+                preallocateSslBuffer(openSslConfig.preallocateSslBuffer);
+                threadLocalSslBuffer(openSslConfig.threadLocalSslBuffer);
                 sslVersion(openSslConfig.sslVersion);
                 nextProtocols(openSslConfig.nextProtocols);
                 clientCAFile(openSslConfig.clientCAFile);
@@ -167,6 +188,9 @@ public class OpenSslServerConfiguration extends SslServerConfiguration {
     public final long sessionTimeoutSeconds;
     public final long sessionCacheSize;
     public final boolean enableStatefulSessionCache;
+    public final int maxSslBufferBytes;
+    public final boolean preallocateSslBuffer;
+    public final boolean threadLocalSslBuffer;
     public final SSLVersion sslVersion;
     public final Iterable<String> nextProtocols;
     public final File clientCAFile;
@@ -179,6 +203,9 @@ public class OpenSslServerConfiguration extends SslServerConfiguration {
         this.sessionTimeoutSeconds = builder.sessionTimeoutSeconds;
         this.sessionCacheSize = builder.sessionCacheSize;
         this.enableStatefulSessionCache = builder.enableStatefulSessionCache;
+        this.maxSslBufferBytes = builder.maxSslBufferBytes;
+        this.preallocateSslBuffer = builder.preallocateSslBuffer;
+        this.threadLocalSslBuffer = builder.threadLocalSslBuffer;
         this.sslVersion = builder.sslVersion;
         this.nextProtocols = builder.nextProtocols;
         this.clientCAFile = builder.clientCAFile;

--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/ThreadLocalSslBufferPool.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/ThreadLocalSslBufferPool.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2012-2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.ssl;
+
+import org.jboss.netty.handler.ssl.SslBufferPool;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import static com.facebook.nifty.core.NettyConfigBuilderBase.DEFAULT_WORKER_THREAD_COUNT;
+
+public class ThreadLocalSslBufferPool extends SslBufferPool {
+    private final ThreadLocal<NonBlockingSslBufferPool> pool;
+
+    public ThreadLocalSslBufferPool(int maxPoolSize, boolean preallocate, boolean allocateDirect) {
+        this(maxPoolSize, preallocate, allocateDirect, DEFAULT_WORKER_THREAD_COUNT);
+    }
+
+    public ThreadLocalSslBufferPool(int maxPoolSize, boolean preallocate, boolean allocateDirect, int numWorkerThreads) {
+        if (maxPoolSize <= 0) {
+            throw new IllegalArgumentException("maxPoolSize: " + maxPoolSize);
+        }
+        pool = new ThreadLocal<NonBlockingSslBufferPool>() {
+            @Override
+            protected NonBlockingSslBufferPool initialValue() {
+                int threadLocalMaxPoolSize = maxPoolSize / numWorkerThreads;
+                if (maxPoolSize % numWorkerThreads != 0) {
+                    threadLocalMaxPoolSize++;
+                }
+                return new NonBlockingSslBufferPool(threadLocalMaxPoolSize, preallocate, allocateDirect);
+            }
+        };
+    }
+
+    @Override
+    public int getMaxPoolSize() {
+        return pool.get().getMaxPoolSize();
+    }
+
+    @Override
+    public int getUnacquiredPoolSize() {
+        return pool.get().getUnacquiredPoolSize();
+    }
+
+    @Override
+    public ByteBuffer acquireBuffer() {
+        return pool.get().acquireBuffer();
+    }
+
+    @Override
+    public void releaseBuffer(ByteBuffer buffer) {
+        pool.get().releaseBuffer(buffer);
+    }
+
+    public static int getBufferSize() { return NonBlockingSslBufferPool.getBufferSize(); }
+
+    /**
+     * A lot of this code is taken from Netty's SslBufferPool.
+     * https://github.com/netty/netty/blob/3.10/src/main/java/org/jboss/netty/handler/ssl/SslBufferPool.java
+     * If we use threadLocal SslBufferPool with a maxPoolSize limit and the thread runs out of preallocated buffer
+     * space, the IO thread will block as it waits for memory to freed and will deadlock. NonBlockingSslBufferPoll
+     * allows us to create a SslBufferPool that will not block when the thread runs out of preallocated buffer space.
+     */
+    private static class NonBlockingSslBufferPool {
+        private static final int MAX_PLAINTEXT_LENGTH = 16 * 1024; // 2^14
+        private static final int MAX_COMPRESSED_LENGTH = MAX_PLAINTEXT_LENGTH + 1024;
+        private static final int MAX_CIPHERTEXT_LENGTH = MAX_COMPRESSED_LENGTH + 1024;
+
+        // Header (5) + Data (2^14) + Compression (1024) + Encryption (1024) + MAC (20) + Padding (256)
+        private static final int MAX_ENCRYPTED_PACKET_LENGTH = MAX_CIPHERTEXT_LENGTH + 5 + 20 + 256;
+
+        // Add 1024 as a room for compressed data and another 1024 for Apache Harmony compatibility.
+        private static final int MAX_PACKET_SIZE_ALIGNED = (MAX_ENCRYPTED_PACKET_LENGTH / 128 + 1) * 128;
+
+        private final BlockingQueue<ByteBuffer> pool;
+        private final int maxBufferCount;
+        private final boolean allocateDirect;
+
+        public NonBlockingSslBufferPool(int maxPoolSize, boolean preallocate, boolean allocateDirect) {
+            int maxBufferCount = maxPoolSize / MAX_PACKET_SIZE_ALIGNED;
+            if (maxPoolSize % MAX_PACKET_SIZE_ALIGNED != 0) {
+                maxBufferCount++;
+            }
+
+            this.maxBufferCount = maxBufferCount;
+            this.allocateDirect = allocateDirect;
+
+            pool = new ArrayBlockingQueue<ByteBuffer>(maxBufferCount);
+
+            if (preallocate) {
+                ByteBuffer preallocated = allocate(maxBufferCount * MAX_PACKET_SIZE_ALIGNED);
+                for (int i = 0; i < maxBufferCount; i++) {
+                    int pos = i * MAX_PACKET_SIZE_ALIGNED;
+                    preallocated.clear().position(pos).limit(pos + MAX_PACKET_SIZE_ALIGNED);
+                    pool.add(preallocated.slice());
+                }
+            }
+        }
+
+        public int getMaxPoolSize() {
+            return maxBufferCount * MAX_PACKET_SIZE_ALIGNED;
+        }
+
+        public int getUnacquiredPoolSize() {
+            return pool.size() * MAX_PACKET_SIZE_ALIGNED;
+        }
+
+        public static int getBufferSize() { return MAX_PACKET_SIZE_ALIGNED; }
+
+        public ByteBuffer acquireBuffer() {
+            ByteBuffer buf = pool.poll();
+            if (buf == null) {
+                buf = allocate(MAX_PACKET_SIZE_ALIGNED);
+            }
+
+            buf.clear();
+            return buf;
+        }
+
+        public void releaseBuffer(ByteBuffer buffer) {
+            if (buffer != null) {
+                pool.offer(buffer);
+            }
+        }
+
+        private ByteBuffer allocate(int capacity) {
+            if (allocateDirect) {
+                return ByteBuffer.allocateDirect(capacity);
+            } else {
+                return ByteBuffer.allocate(capacity);
+            }
+        }
+    }
+}

--- a/nifty-ssl/src/test/java/com/facebook/nifty/ssl/ThreadLocalSslBufferPoolTest.java
+++ b/nifty-ssl/src/test/java/com/facebook/nifty/ssl/ThreadLocalSslBufferPoolTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2012-2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.nifty.ssl;
+
+import org.jboss.netty.handler.ssl.SslBufferPool;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+
+public class ThreadLocalSslBufferPoolTest {
+    @Test
+    public void testMultipleThreads() {
+        int numThreads = 5;
+        int maxPoolSize = ThreadLocalSslBufferPool.getBufferSize() * numThreads;
+        SslBufferPool pool = new ThreadLocalSslBufferPool(maxPoolSize, true, true, numThreads);
+        Assert.assertEquals(pool.getMaxPoolSize(), ThreadLocalSslBufferPool.getBufferSize());
+        Assert.assertEquals(pool.getUnacquiredPoolSize(), ThreadLocalSslBufferPool.getBufferSize());
+    }
+
+    @Test
+    public void testPreallocated() {
+        int maxPoolSize = ThreadLocalSslBufferPool.getBufferSize() * 5;
+        SslBufferPool pool = new ThreadLocalSslBufferPool(maxPoolSize, true, true, 1);
+        Assert.assertEquals(pool.getMaxPoolSize(), maxPoolSize);
+        Assert.assertEquals(pool.getUnacquiredPoolSize(), maxPoolSize);
+
+        ByteBuffer buf = null;
+        try {
+            buf = pool.acquireBuffer();
+            Assert.assertEquals(buf.capacity(), ThreadLocalSslBufferPool.getBufferSize());
+            Assert.assertEquals(pool.getUnacquiredPoolSize(), maxPoolSize - ThreadLocalSslBufferPool.getBufferSize());
+        } finally {
+            pool.releaseBuffer(buf);
+        }
+    }
+
+    @Test
+    public void testNonPreallocated() {
+        int maxPoolSize = ThreadLocalSslBufferPool.getBufferSize() * 5;
+        SslBufferPool pool = new ThreadLocalSslBufferPool(maxPoolSize, false, true, 1);
+        Assert.assertEquals(pool.getMaxPoolSize(), maxPoolSize);
+        Assert.assertEquals(pool.getUnacquiredPoolSize(), 0);
+
+        ByteBuffer buf = null;
+        try {
+            buf = pool.acquireBuffer();
+            Assert.assertEquals(buf.capacity(), ThreadLocalSslBufferPool.getBufferSize());
+            Assert.assertEquals(pool.getUnacquiredPoolSize(), 0);
+        } finally {
+            pool.releaseBuffer(buf);
+        }
+        Assert.assertEquals(pool.getUnacquiredPoolSize(), ThreadLocalSslBufferPool.getBufferSize());
+    }
+
+    @Test
+    public void testNonBlockingAcquireBuffer() {
+        SslBufferPool pool = new ThreadLocalSslBufferPool(1, true, true, 1);
+
+        ByteBuffer buf1 = null;
+        ByteBuffer buf2 = null;
+        try {
+            buf1 = pool.acquireBuffer();
+            Assert.assertEquals(pool.getUnacquiredPoolSize(), 0);
+            // Try to acquire buffer. Unlike SslBufferPool, this should not block and will return another buffer.
+            buf2 = pool.acquireBuffer();
+        } finally {
+            pool.releaseBuffer(buf1);
+            pool.releaseBuffer(buf2);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidMaxPoolSize() {
+        SslBufferPool pool = new ThreadLocalSslBufferPool(0, true, true, 1);
+    }
+}


### PR DESCRIPTION
The netty SslBufferPool uses an ArrayBlockingQueue, which uses locking to read and write from the buffer queue. To avoid contention for this buffer pool lock, each IO thread now has its own SslBufferPool objects.

Also added preallocateSslBuffer and maxSslBufferSize for configurability purposes.
