### PR TITLE
Fixes binary operator to be a logical operator

### DIFF
--- a/nifty-ssl/src/main/java/com/facebook/nifty/ssl/NettyTcNativeLoader.java
+++ b/nifty-ssl/src/main/java/com/facebook/nifty/ssl/NettyTcNativeLoader.java
@@ -130,7 +130,7 @@ public class NettyTcNativeLoader {
         }
         finally {
             // Restore the fields to their original values
-            if (exceptionField != null && modifiersField != null & setModifiers) {
+            if (exceptionField != null && modifiersField != null && setModifiers) {
                 try {
                     modifiersField.setInt(exceptionField, originalModifiers);
                 }


### PR DESCRIPTION
This condition should be using a logical AND. Right now it's taking a binary AND of a boolean. This actually works logically in Java, but in general it will be less confusing if we just use &&.